### PR TITLE
Adding STM32F103 Medium Density 64pin LQFP

### DIFF
--- a/ELL-i-DigitalIC.lbr
+++ b/ELL-i-DigitalIC.lbr
@@ -5539,7 +5539,9 @@ Quad 2:1 Multiplexer / Demultiplexer Bus Switch
 <connect gate="G$1" pin="VSSA" pad="12"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="PARTNO" value="STM32F103RB" constant="no"/>
+</technology>
 </technologies>
 </device>
 </devices>


### PR DESCRIPTION
"Adding STM32F103 Medium Density 64pin LQFP" and "Added part number to STM32F103":

This is the embedded processor used in the black magic probe debugging tool. We will be using the same processor as well for the USB debugging side. 
