### PR TITLE
Add handsoldering footprint for MLP8L33

### DIFF
--- a/ELL-i-DiscreteSemi.lbr
+++ b/ELL-i-DiscreteSemi.lbr
@@ -385,6 +385,47 @@ Source: http://www.onsemi.com/pub_link/Collateral/MBRA340T3-D.PDF</description>
 <rectangle x1="-2.7432" y1="-3.6576" x2="-1.8796" y2="-1.8034" layer="51"/>
 <rectangle x1="1.8796" y1="-3.6576" x2="2.7432" y2="-1.8034" layer="51"/>
 </package>
+<package name="MLP8L33_HS">
+<description>&lt;h3&gt;MLP8L33&lt;/h3&gt;
+&lt;p&gt;
+Footprint with extended pads for handsoldering. &lt;a href="http://www.fairchildsemi.com/package/packageDetails.html?id=PN_MLOEU-008"&gt;Package web page&lt;/a&gt;
+&lt;/p&gt;</description>
+<wire x1="-1.45" y1="1.65" x2="-1.3" y2="1.65" width="0.1016" layer="21"/>
+<wire x1="-1.3" y1="1.65" x2="1.3" y2="1.65" width="0.1016" layer="51"/>
+<wire x1="1.3" y1="1.65" x2="1.45" y2="1.65" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="1.65" x2="1.45" y2="0.3625" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="0.3625" x2="1.45" y2="-0.375" width="0.1016" layer="51"/>
+<wire x1="1.45" y1="-0.3625" x2="1.45" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="-1.65" x2="1.3" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="1.3" y1="-1.65" x2="-1.3" y2="-1.65" width="0.1016" layer="51"/>
+<wire x1="-1.3" y1="-1.65" x2="-1.45" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="-1.45" y1="-1.65" x2="-1.45" y2="-0.3625" width="0.1016" layer="21"/>
+<wire x1="-1.45" y1="-0.3625" x2="-1.45" y2="0.3625" width="0.1016" layer="51"/>
+<wire x1="-1.45" y1="0.3625" x2="-1.45" y2="1.65" width="0.1016" layer="21"/>
+<circle x="-1.2" y="-1.075" radius="0.125" width="0" layer="21"/>
+<smd name="1" x="-0.975" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="2" x="-0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="3" x="0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="4" x="0.975" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="5" x="0.975" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="6" x="0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="7" x="-0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="8" x="-0.975" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<text x="-1.27" y="1.87" size="0.6096" layer="25">&gt;NAME</text>
+<text x="-1.37" y="-2.505" size="0.6096" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.1375" y1="1.275" x2="-0.8125" y2="1.725" layer="51"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="0.1625" y1="1.275" x2="0.4875" y2="1.725" layer="51"/>
+<rectangle x1="0.8125" y1="1.275" x2="1.1375" y2="1.725" layer="51"/>
+<rectangle x1="0.8125" y1="-1.725" x2="1.1375" y2="-1.275" layer="51"/>
+<rectangle x1="0.1625" y1="-1.725" x2="0.4875" y2="-1.275" layer="51"/>
+<rectangle x1="-0.4875" y1="-1.725" x2="-0.1625" y2="-1.275" layer="51"/>
+<rectangle x1="-1.1375" y1="-1.725" x2="-0.8125" y2="-1.275" layer="51"/>
+<smd name="F1" x="0" y="0.45" dx="2.37" dy="1.7" layer="1"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="0.1325" y1="1.275" x2="0.4575" y2="1.725" layer="51"/>
+</package>
 </packages>
 <symbols>
 <symbol name="DIODE-SCHOTTKY">


### PR DESCRIPTION
Extends pads 0.4mm out for easier hand soldering of package. 
