### PR TITLE
Bugfix: Enlarge drill size for pin headers from 0.8 mm to 1.0 mm

### DIFF
--- a/ELL-i-Boards.lbr
+++ b/ELL-i-Boards.lbr
@@ -279,114 +279,114 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="69" y1="82.5" x2="70" y2="81.5" width="0.127" layer="20" curve="-90"/>
 <wire x1="1" y1="1" x2="0" y2="2" width="0.127" layer="20" curve="-90"/>
 <wire x1="70" y1="2" x2="69" y2="1" width="0.127" layer="20" curve="-90"/>
-<pad name="CN7_37" x="3.25" y="4.04" drill="0.8"/>
-<pad name="CN10_38" x="66.75" y="4.04" drill="0.8"/>
-<pad name="CN7_33" x="3.25" y="9.12" drill="0.8"/>
-<pad name="CN7_31" x="3.25" y="11.66" drill="0.8"/>
-<pad name="CN7_29" x="3.25" y="14.2" drill="0.8"/>
-<pad name="CN7_27" x="3.25" y="16.74" drill="0.8"/>
-<pad name="CN7_25" x="3.25" y="19.28" drill="0.8"/>
-<pad name="CN7_23" x="3.25" y="21.82" drill="0.8"/>
-<pad name="CN7_21" x="3.25" y="24.36" drill="0.8"/>
-<pad name="CN7_35" x="3.25" y="6.58" drill="0.8"/>
-<pad name="CN7_19" x="3.25" y="26.9" drill="0.8"/>
-<pad name="CN7_17" x="3.25" y="29.44" drill="0.8"/>
-<pad name="CN7_15" x="3.25" y="31.98" drill="0.8"/>
-<pad name="CN7_13" x="3.25" y="34.52" drill="0.8"/>
-<pad name="CN7_11" x="3.25" y="37.06" drill="0.8"/>
-<pad name="CN7_9" x="3.25" y="39.6" drill="0.8"/>
-<pad name="CN7_7" x="3.25" y="42.14" drill="0.8"/>
-<pad name="CN7_5" x="3.25" y="44.68" drill="0.8"/>
-<pad name="CN7_3" x="3.25" y="47.22" drill="0.8"/>
-<pad name="CN7_1" x="3.25" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN7_38" x="5.79" y="4.04" drill="0.8"/>
-<pad name="CN7_34" x="5.79" y="9.12" drill="0.8"/>
-<pad name="CN7_32" x="5.79" y="11.66" drill="0.8"/>
-<pad name="CN7_30" x="5.79" y="14.2" drill="0.8"/>
-<pad name="CN7_28" x="5.79" y="16.74" drill="0.8"/>
-<pad name="CN7_26" x="5.79" y="19.28" drill="0.8"/>
-<pad name="CN7_24" x="5.79" y="21.82" drill="0.8"/>
-<pad name="CN7_22" x="5.79" y="24.36" drill="0.8"/>
-<pad name="CN7_36" x="5.79" y="6.58" drill="0.8"/>
-<pad name="CN7_20" x="5.79" y="26.9" drill="0.8"/>
-<pad name="CN7_18" x="5.79" y="29.44" drill="0.8"/>
-<pad name="CN7_16" x="5.79" y="31.98" drill="0.8"/>
-<pad name="CN7_14" x="5.79" y="34.52" drill="0.8"/>
-<pad name="CN7_12" x="5.79" y="37.06" drill="0.8"/>
-<pad name="CN7_10" x="5.79" y="39.6" drill="0.8"/>
-<pad name="CN7_8" x="5.79" y="42.14" drill="0.8"/>
-<pad name="CN7_6" x="5.79" y="44.68" drill="0.8"/>
-<pad name="CN7_4" x="5.79" y="47.22" drill="0.8"/>
-<pad name="CN7_2" x="5.79" y="49.76" drill="0.8"/>
-<pad name="CN8_6" x="10.87" y="4.04" drill="0.8"/>
-<pad name="CN8_4" x="10.87" y="9.12" drill="0.8"/>
-<pad name="CN8_3" x="10.87" y="11.66" drill="0.8"/>
-<pad name="CN8_2" x="10.87" y="14.2" drill="0.8"/>
-<pad name="CN8_1" x="10.87" y="16.74" drill="0.8" shape="square"/>
-<pad name="CN6_8" x="10.87" y="21.82" drill="0.8"/>
-<pad name="CN6_7" x="10.87" y="24.36" drill="0.8"/>
-<pad name="CN8_5" x="10.87" y="6.58" drill="0.8"/>
-<pad name="CN6_6" x="10.87" y="26.9" drill="0.8"/>
-<pad name="CN6_5" x="10.87" y="29.44" drill="0.8"/>
-<pad name="CN6_4" x="10.87" y="31.98" drill="0.8"/>
-<pad name="CN6_3" x="10.87" y="34.52" drill="0.8"/>
-<pad name="CN6_2" x="10.87" y="37.06" drill="0.8"/>
-<pad name="CN6_1" x="10.87" y="39.6" drill="0.8" shape="square"/>
-<pad name="CN10_36" x="66.75" y="6.58" drill="0.8"/>
-<pad name="CN10_34" x="66.75" y="9.12" drill="0.8"/>
-<pad name="CN10_32" x="66.75" y="11.66" drill="0.8"/>
-<pad name="CN10_30" x="66.75" y="14.2" drill="0.8"/>
-<pad name="CN10_28" x="66.75" y="16.74" drill="0.8"/>
-<pad name="CN10_26" x="66.75" y="19.28" drill="0.8"/>
-<pad name="CN10_24" x="66.75" y="21.82" drill="0.8"/>
-<pad name="CN10_22" x="66.75" y="24.36" drill="0.8"/>
-<pad name="CN10_20" x="66.75" y="26.9" drill="0.8"/>
-<pad name="CN10_18" x="66.75" y="29.44" drill="0.8"/>
-<pad name="CN10_16" x="66.75" y="31.98" drill="0.8"/>
-<pad name="CN10_14" x="66.75" y="34.52" drill="0.8"/>
-<pad name="CN10_12" x="66.75" y="37.06" drill="0.8"/>
-<pad name="CN10_10" x="66.75" y="39.6" drill="0.8"/>
-<pad name="CN10_8" x="66.75" y="42.14" drill="0.8"/>
-<pad name="CN10_6" x="66.75" y="44.68" drill="0.8"/>
-<pad name="CN10_4" x="66.75" y="47.22" drill="0.8"/>
-<pad name="CN10_2" x="66.75" y="49.76" drill="0.8"/>
-<pad name="CN10_37" x="64.21" y="4.04" drill="0.8"/>
-<pad name="CN10_35" x="64.21" y="6.58" drill="0.8"/>
-<pad name="CN10_33" x="64.21" y="9.12" drill="0.8"/>
-<pad name="CN10_31" x="64.21" y="11.66" drill="0.8"/>
-<pad name="CN10_29" x="64.21" y="14.2" drill="0.8"/>
-<pad name="CN10_27" x="64.21" y="16.74" drill="0.8"/>
-<pad name="CN10_25" x="64.21" y="19.28" drill="0.8"/>
-<pad name="CN10_23" x="64.21" y="21.82" drill="0.8"/>
-<pad name="CN10_21" x="64.21" y="24.36" drill="0.8"/>
-<pad name="CN10_19" x="64.21" y="26.9" drill="0.8"/>
-<pad name="CN10_17" x="64.21" y="29.44" drill="0.8"/>
-<pad name="CN10_15" x="64.21" y="31.98" drill="0.8"/>
-<pad name="CN10_13" x="64.21" y="34.52" drill="0.8"/>
-<pad name="CN10_11" x="64.21" y="37.06" drill="0.8"/>
-<pad name="CN10_9" x="64.21" y="39.6" drill="0.8"/>
-<pad name="CN10_7" x="64.21" y="42.14" drill="0.8"/>
-<pad name="CN10_5" x="64.21" y="44.68" drill="0.8"/>
-<pad name="CN10_3" x="64.21" y="47.22" drill="0.8"/>
-<pad name="CN10_1" x="64.21" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN9_1" x="59.13" y="4.04" drill="0.8" shape="square"/>
-<pad name="CN9_3" x="59.13" y="9.12" drill="0.8"/>
-<pad name="CN9_4" x="59.13" y="11.66" drill="0.8"/>
-<pad name="CN9_5" x="59.13" y="14.2" drill="0.8"/>
-<pad name="CN9_6" x="59.13" y="16.74" drill="0.8"/>
-<pad name="CN9_7" x="59.13" y="19.28" drill="0.8"/>
-<pad name="CN9_8" x="59.13" y="21.82" drill="0.8"/>
-<pad name="CN9_2" x="59.13" y="6.58" drill="0.8"/>
-<pad name="CN5_1" x="59.13" y="25.63" drill="0.8" shape="square"/>
-<pad name="CN5_2" x="59.13" y="28.17" drill="0.8"/>
-<pad name="CN5_3" x="59.13" y="30.71" drill="0.8"/>
-<pad name="CN5_4" x="59.13" y="33.25" drill="0.8"/>
-<pad name="CN5_5" x="59.13" y="35.79" drill="0.8"/>
-<pad name="CN5_6" x="59.13" y="38.33" drill="0.8"/>
-<pad name="CN5_7" x="59.13" y="40.87" drill="0.8"/>
-<pad name="CN5_8" x="59.13" y="43.41" drill="0.8"/>
-<pad name="CN5_9" x="59.13" y="45.95" drill="0.8"/>
-<pad name="CN5_10" x="59.13" y="48.49" drill="0.8"/>
+<pad name="CN7_37" x="3.25" y="4.04" drill="1"/>
+<pad name="CN10_38" x="66.75" y="4.04" drill="1"/>
+<pad name="CN7_33" x="3.25" y="9.12" drill="1"/>
+<pad name="CN7_31" x="3.25" y="11.66" drill="1"/>
+<pad name="CN7_29" x="3.25" y="14.2" drill="1"/>
+<pad name="CN7_27" x="3.25" y="16.74" drill="1"/>
+<pad name="CN7_25" x="3.25" y="19.28" drill="1"/>
+<pad name="CN7_23" x="3.25" y="21.82" drill="1"/>
+<pad name="CN7_21" x="3.25" y="24.36" drill="1"/>
+<pad name="CN7_35" x="3.25" y="6.58" drill="1"/>
+<pad name="CN7_19" x="3.25" y="26.9" drill="1"/>
+<pad name="CN7_17" x="3.25" y="29.44" drill="1"/>
+<pad name="CN7_15" x="3.25" y="31.98" drill="1"/>
+<pad name="CN7_13" x="3.25" y="34.52" drill="1"/>
+<pad name="CN7_11" x="3.25" y="37.06" drill="1"/>
+<pad name="CN7_9" x="3.25" y="39.6" drill="1"/>
+<pad name="CN7_7" x="3.25" y="42.14" drill="1"/>
+<pad name="CN7_5" x="3.25" y="44.68" drill="1"/>
+<pad name="CN7_3" x="3.25" y="47.22" drill="1"/>
+<pad name="CN7_1" x="3.25" y="49.76" drill="1" shape="square"/>
+<pad name="CN7_38" x="5.79" y="4.04" drill="1"/>
+<pad name="CN7_34" x="5.79" y="9.12" drill="1"/>
+<pad name="CN7_32" x="5.79" y="11.66" drill="1"/>
+<pad name="CN7_30" x="5.79" y="14.2" drill="1"/>
+<pad name="CN7_28" x="5.79" y="16.74" drill="1"/>
+<pad name="CN7_26" x="5.79" y="19.28" drill="1"/>
+<pad name="CN7_24" x="5.79" y="21.82" drill="1"/>
+<pad name="CN7_22" x="5.79" y="24.36" drill="1"/>
+<pad name="CN7_36" x="5.79" y="6.58" drill="1"/>
+<pad name="CN7_20" x="5.79" y="26.9" drill="1"/>
+<pad name="CN7_18" x="5.79" y="29.44" drill="1"/>
+<pad name="CN7_16" x="5.79" y="31.98" drill="1"/>
+<pad name="CN7_14" x="5.79" y="34.52" drill="1"/>
+<pad name="CN7_12" x="5.79" y="37.06" drill="1"/>
+<pad name="CN7_10" x="5.79" y="39.6" drill="1"/>
+<pad name="CN7_8" x="5.79" y="42.14" drill="1"/>
+<pad name="CN7_6" x="5.79" y="44.68" drill="1"/>
+<pad name="CN7_4" x="5.79" y="47.22" drill="1"/>
+<pad name="CN7_2" x="5.79" y="49.76" drill="1"/>
+<pad name="CN8_6" x="10.87" y="4.04" drill="1"/>
+<pad name="CN8_4" x="10.87" y="9.12" drill="1"/>
+<pad name="CN8_3" x="10.87" y="11.66" drill="1"/>
+<pad name="CN8_2" x="10.87" y="14.2" drill="1"/>
+<pad name="CN8_1" x="10.87" y="16.74" drill="1" shape="square"/>
+<pad name="CN6_8" x="10.87" y="21.82" drill="1"/>
+<pad name="CN6_7" x="10.87" y="24.36" drill="1"/>
+<pad name="CN8_5" x="10.87" y="6.58" drill="1"/>
+<pad name="CN6_6" x="10.87" y="26.9" drill="1"/>
+<pad name="CN6_5" x="10.87" y="29.44" drill="1"/>
+<pad name="CN6_4" x="10.87" y="31.98" drill="1"/>
+<pad name="CN6_3" x="10.87" y="34.52" drill="1"/>
+<pad name="CN6_2" x="10.87" y="37.06" drill="1"/>
+<pad name="CN6_1" x="10.87" y="39.6" drill="1" shape="square"/>
+<pad name="CN10_36" x="66.75" y="6.58" drill="1"/>
+<pad name="CN10_34" x="66.75" y="9.12" drill="1"/>
+<pad name="CN10_32" x="66.75" y="11.66" drill="1"/>
+<pad name="CN10_30" x="66.75" y="14.2" drill="1"/>
+<pad name="CN10_28" x="66.75" y="16.74" drill="1"/>
+<pad name="CN10_26" x="66.75" y="19.28" drill="1"/>
+<pad name="CN10_24" x="66.75" y="21.82" drill="1"/>
+<pad name="CN10_22" x="66.75" y="24.36" drill="1"/>
+<pad name="CN10_20" x="66.75" y="26.9" drill="1"/>
+<pad name="CN10_18" x="66.75" y="29.44" drill="1"/>
+<pad name="CN10_16" x="66.75" y="31.98" drill="1"/>
+<pad name="CN10_14" x="66.75" y="34.52" drill="1"/>
+<pad name="CN10_12" x="66.75" y="37.06" drill="1"/>
+<pad name="CN10_10" x="66.75" y="39.6" drill="1"/>
+<pad name="CN10_8" x="66.75" y="42.14" drill="1"/>
+<pad name="CN10_6" x="66.75" y="44.68" drill="1"/>
+<pad name="CN10_4" x="66.75" y="47.22" drill="1"/>
+<pad name="CN10_2" x="66.75" y="49.76" drill="1"/>
+<pad name="CN10_37" x="64.21" y="4.04" drill="1"/>
+<pad name="CN10_35" x="64.21" y="6.58" drill="1"/>
+<pad name="CN10_33" x="64.21" y="9.12" drill="1"/>
+<pad name="CN10_31" x="64.21" y="11.66" drill="1"/>
+<pad name="CN10_29" x="64.21" y="14.2" drill="1"/>
+<pad name="CN10_27" x="64.21" y="16.74" drill="1"/>
+<pad name="CN10_25" x="64.21" y="19.28" drill="1"/>
+<pad name="CN10_23" x="64.21" y="21.82" drill="1"/>
+<pad name="CN10_21" x="64.21" y="24.36" drill="1"/>
+<pad name="CN10_19" x="64.21" y="26.9" drill="1"/>
+<pad name="CN10_17" x="64.21" y="29.44" drill="1"/>
+<pad name="CN10_15" x="64.21" y="31.98" drill="1"/>
+<pad name="CN10_13" x="64.21" y="34.52" drill="1"/>
+<pad name="CN10_11" x="64.21" y="37.06" drill="1"/>
+<pad name="CN10_9" x="64.21" y="39.6" drill="1"/>
+<pad name="CN10_7" x="64.21" y="42.14" drill="1"/>
+<pad name="CN10_5" x="64.21" y="44.68" drill="1"/>
+<pad name="CN10_3" x="64.21" y="47.22" drill="1"/>
+<pad name="CN10_1" x="64.21" y="49.76" drill="1" shape="square"/>
+<pad name="CN9_1" x="59.13" y="4.04" drill="1" shape="square"/>
+<pad name="CN9_3" x="59.13" y="9.12" drill="1"/>
+<pad name="CN9_4" x="59.13" y="11.66" drill="1"/>
+<pad name="CN9_5" x="59.13" y="14.2" drill="1"/>
+<pad name="CN9_6" x="59.13" y="16.74" drill="1"/>
+<pad name="CN9_7" x="59.13" y="19.28" drill="1"/>
+<pad name="CN9_8" x="59.13" y="21.82" drill="1"/>
+<pad name="CN9_2" x="59.13" y="6.58" drill="1"/>
+<pad name="CN5_1" x="59.13" y="25.63" drill="1" shape="square"/>
+<pad name="CN5_2" x="59.13" y="28.17" drill="1"/>
+<pad name="CN5_3" x="59.13" y="30.71" drill="1"/>
+<pad name="CN5_4" x="59.13" y="33.25" drill="1"/>
+<pad name="CN5_5" x="59.13" y="35.79" drill="1"/>
+<pad name="CN5_6" x="59.13" y="38.33" drill="1"/>
+<pad name="CN5_7" x="59.13" y="40.87" drill="1"/>
+<pad name="CN5_8" x="59.13" y="43.41" drill="1"/>
+<pad name="CN5_9" x="59.13" y="45.95" drill="1"/>
+<pad name="CN5_10" x="59.13" y="48.49" drill="1"/>
 <wire x1="5.7912" y1="34.5186" x2="10.8712" y2="34.5186" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="37.0586" x2="10.8712" y2="37.0586" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="39.5986" x2="10.8712" y2="39.5986" width="0.127" layer="1"/>
@@ -539,114 +539,114 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="69" y1="57.5" x2="70" y2="56.5" width="0.127" layer="20" curve="-90"/>
 <wire x1="1" y1="1" x2="0" y2="2" width="0.127" layer="20" curve="-90"/>
 <wire x1="70" y1="2" x2="69" y2="1" width="0.127" layer="20" curve="-90"/>
-<pad name="CN7_37" x="3.25" y="4.04" drill="0.8"/>
-<pad name="CN10_38" x="66.75" y="4.04" drill="0.8"/>
-<pad name="CN7_33" x="3.25" y="9.12" drill="0.8"/>
-<pad name="CN7_31" x="3.25" y="11.66" drill="0.8"/>
-<pad name="CN7_29" x="3.25" y="14.2" drill="0.8"/>
-<pad name="CN7_27" x="3.25" y="16.74" drill="0.8"/>
-<pad name="CN7_25" x="3.25" y="19.28" drill="0.8"/>
-<pad name="CN7_23" x="3.25" y="21.82" drill="0.8"/>
-<pad name="CN7_21" x="3.25" y="24.36" drill="0.8"/>
-<pad name="CN7_35" x="3.25" y="6.58" drill="0.8"/>
-<pad name="CN7_19" x="3.25" y="26.9" drill="0.8"/>
-<pad name="CN7_17" x="3.25" y="29.44" drill="0.8"/>
-<pad name="CN7_15" x="3.25" y="31.98" drill="0.8"/>
-<pad name="CN7_13" x="3.25" y="34.52" drill="0.8"/>
-<pad name="CN7_11" x="3.25" y="37.06" drill="0.8"/>
-<pad name="CN7_9" x="3.25" y="39.6" drill="0.8"/>
-<pad name="CN7_7" x="3.25" y="42.14" drill="0.8"/>
-<pad name="CN7_5" x="3.25" y="44.68" drill="0.8"/>
-<pad name="CN7_3" x="3.25" y="47.22" drill="0.8"/>
-<pad name="CN7_1" x="3.25" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN7_38" x="5.79" y="4.04" drill="0.8"/>
-<pad name="CN7_34" x="5.79" y="9.12" drill="0.8"/>
-<pad name="CN7_32" x="5.79" y="11.66" drill="0.8"/>
-<pad name="CN7_30" x="5.79" y="14.2" drill="0.8"/>
-<pad name="CN7_28" x="5.79" y="16.74" drill="0.8"/>
-<pad name="CN7_26" x="5.79" y="19.28" drill="0.8"/>
-<pad name="CN7_24" x="5.79" y="21.82" drill="0.8"/>
-<pad name="CN7_22" x="5.79" y="24.36" drill="0.8"/>
-<pad name="CN7_36" x="5.79" y="6.58" drill="0.8"/>
-<pad name="CN7_20" x="5.79" y="26.9" drill="0.8"/>
-<pad name="CN7_18" x="5.79" y="29.44" drill="0.8"/>
-<pad name="CN7_16" x="5.79" y="31.98" drill="0.8"/>
-<pad name="CN7_14" x="5.79" y="34.52" drill="0.8"/>
-<pad name="CN7_12" x="5.79" y="37.06" drill="0.8"/>
-<pad name="CN7_10" x="5.79" y="39.6" drill="0.8"/>
-<pad name="CN7_8" x="5.79" y="42.14" drill="0.8"/>
-<pad name="CN7_6" x="5.79" y="44.68" drill="0.8"/>
-<pad name="CN7_4" x="5.79" y="47.22" drill="0.8"/>
-<pad name="CN7_2" x="5.79" y="49.76" drill="0.8"/>
-<pad name="CN8_6" x="10.87" y="4.04" drill="0.8"/>
-<pad name="CN8_4" x="10.87" y="9.12" drill="0.8"/>
-<pad name="CN8_3" x="10.87" y="11.66" drill="0.8"/>
-<pad name="CN8_2" x="10.87" y="14.2" drill="0.8"/>
-<pad name="CN8_1" x="10.87" y="16.74" drill="0.8" shape="square"/>
-<pad name="CN6_8" x="10.87" y="21.82" drill="0.8"/>
-<pad name="CN6_7" x="10.87" y="24.36" drill="0.8"/>
-<pad name="CN8_5" x="10.87" y="6.58" drill="0.8"/>
-<pad name="CN6_6" x="10.87" y="26.9" drill="0.8"/>
-<pad name="CN6_5" x="10.87" y="29.44" drill="0.8"/>
-<pad name="CN6_4" x="10.87" y="31.98" drill="0.8"/>
-<pad name="CN6_3" x="10.87" y="34.52" drill="0.8"/>
-<pad name="CN6_2" x="10.87" y="37.06" drill="0.8"/>
-<pad name="CN6_1" x="10.87" y="39.6" drill="0.8" shape="square"/>
-<pad name="CN10_36" x="66.75" y="6.58" drill="0.8"/>
-<pad name="CN10_34" x="66.75" y="9.12" drill="0.8"/>
-<pad name="CN10_32" x="66.75" y="11.66" drill="0.8"/>
-<pad name="CN10_30" x="66.75" y="14.2" drill="0.8"/>
-<pad name="CN10_28" x="66.75" y="16.74" drill="0.8"/>
-<pad name="CN10_26" x="66.75" y="19.28" drill="0.8"/>
-<pad name="CN10_24" x="66.75" y="21.82" drill="0.8"/>
-<pad name="CN10_22" x="66.75" y="24.36" drill="0.8"/>
-<pad name="CN10_20" x="66.75" y="26.9" drill="0.8"/>
-<pad name="CN10_18" x="66.75" y="29.44" drill="0.8"/>
-<pad name="CN10_16" x="66.75" y="31.98" drill="0.8"/>
-<pad name="CN10_14" x="66.75" y="34.52" drill="0.8"/>
-<pad name="CN10_12" x="66.75" y="37.06" drill="0.8"/>
-<pad name="CN10_10" x="66.75" y="39.6" drill="0.8"/>
-<pad name="CN10_8" x="66.75" y="42.14" drill="0.8"/>
-<pad name="CN10_6" x="66.75" y="44.68" drill="0.8"/>
-<pad name="CN10_4" x="66.75" y="47.22" drill="0.8"/>
-<pad name="CN10_2" x="66.75" y="49.76" drill="0.8"/>
-<pad name="CN10_37" x="64.21" y="4.04" drill="0.8"/>
-<pad name="CN10_35" x="64.21" y="6.58" drill="0.8"/>
-<pad name="CN10_33" x="64.21" y="9.12" drill="0.8"/>
-<pad name="CN10_31" x="64.21" y="11.66" drill="0.8"/>
-<pad name="CN10_29" x="64.21" y="14.2" drill="0.8"/>
-<pad name="CN10_27" x="64.21" y="16.74" drill="0.8"/>
-<pad name="CN10_25" x="64.21" y="19.28" drill="0.8"/>
-<pad name="CN10_23" x="64.21" y="21.82" drill="0.8"/>
-<pad name="CN10_21" x="64.21" y="24.36" drill="0.8"/>
-<pad name="CN10_19" x="64.21" y="26.9" drill="0.8"/>
-<pad name="CN10_17" x="64.21" y="29.44" drill="0.8"/>
-<pad name="CN10_15" x="64.21" y="31.98" drill="0.8"/>
-<pad name="CN10_13" x="64.21" y="34.52" drill="0.8"/>
-<pad name="CN10_11" x="64.21" y="37.06" drill="0.8"/>
-<pad name="CN10_9" x="64.21" y="39.6" drill="0.8"/>
-<pad name="CN10_7" x="64.21" y="42.14" drill="0.8"/>
-<pad name="CN10_5" x="64.21" y="44.68" drill="0.8"/>
-<pad name="CN10_3" x="64.21" y="47.22" drill="0.8"/>
-<pad name="CN10_1" x="64.21" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN9_1" x="59.13" y="4.04" drill="0.8" shape="square"/>
-<pad name="CN9_3" x="59.13" y="9.12" drill="0.8"/>
-<pad name="CN9_4" x="59.13" y="11.66" drill="0.8"/>
-<pad name="CN9_5" x="59.13" y="14.2" drill="0.8"/>
-<pad name="CN9_6" x="59.13" y="16.74" drill="0.8"/>
-<pad name="CN9_7" x="59.13" y="19.28" drill="0.8"/>
-<pad name="CN9_8" x="59.13" y="21.82" drill="0.8"/>
-<pad name="CN9_2" x="59.13" y="6.58" drill="0.8"/>
-<pad name="CN5_1" x="59.13" y="25.63" drill="0.8" shape="square"/>
-<pad name="CN5_2" x="59.13" y="28.17" drill="0.8"/>
-<pad name="CN5_3" x="59.13" y="30.71" drill="0.8"/>
-<pad name="CN5_4" x="59.13" y="33.25" drill="0.8"/>
-<pad name="CN5_5" x="59.13" y="35.79" drill="0.8"/>
-<pad name="CN5_6" x="59.13" y="38.33" drill="0.8"/>
-<pad name="CN5_7" x="59.13" y="40.87" drill="0.8"/>
-<pad name="CN5_8" x="59.13" y="43.41" drill="0.8"/>
-<pad name="CN5_9" x="59.13" y="45.95" drill="0.8"/>
-<pad name="CN5_10" x="59.13" y="48.49" drill="0.8"/>
+<pad name="CN7_37" x="3.25" y="4.04" drill="1"/>
+<pad name="CN10_38" x="66.75" y="4.04" drill="1"/>
+<pad name="CN7_33" x="3.25" y="9.12" drill="1"/>
+<pad name="CN7_31" x="3.25" y="11.66" drill="1"/>
+<pad name="CN7_29" x="3.25" y="14.2" drill="1"/>
+<pad name="CN7_27" x="3.25" y="16.74" drill="1"/>
+<pad name="CN7_25" x="3.25" y="19.28" drill="1"/>
+<pad name="CN7_23" x="3.25" y="21.82" drill="1"/>
+<pad name="CN7_21" x="3.25" y="24.36" drill="1"/>
+<pad name="CN7_35" x="3.25" y="6.58" drill="1"/>
+<pad name="CN7_19" x="3.25" y="26.9" drill="1"/>
+<pad name="CN7_17" x="3.25" y="29.44" drill="1"/>
+<pad name="CN7_15" x="3.25" y="31.98" drill="1"/>
+<pad name="CN7_13" x="3.25" y="34.52" drill="1"/>
+<pad name="CN7_11" x="3.25" y="37.06" drill="1"/>
+<pad name="CN7_9" x="3.25" y="39.6" drill="1"/>
+<pad name="CN7_7" x="3.25" y="42.14" drill="1"/>
+<pad name="CN7_5" x="3.25" y="44.68" drill="1"/>
+<pad name="CN7_3" x="3.25" y="47.22" drill="1"/>
+<pad name="CN7_1" x="3.25" y="49.76" drill="1" shape="square"/>
+<pad name="CN7_38" x="5.79" y="4.04" drill="1"/>
+<pad name="CN7_34" x="5.79" y="9.12" drill="1"/>
+<pad name="CN7_32" x="5.79" y="11.66" drill="1"/>
+<pad name="CN7_30" x="5.79" y="14.2" drill="1"/>
+<pad name="CN7_28" x="5.79" y="16.74" drill="1"/>
+<pad name="CN7_26" x="5.79" y="19.28" drill="1"/>
+<pad name="CN7_24" x="5.79" y="21.82" drill="1"/>
+<pad name="CN7_22" x="5.79" y="24.36" drill="1"/>
+<pad name="CN7_36" x="5.79" y="6.58" drill="1"/>
+<pad name="CN7_20" x="5.79" y="26.9" drill="1"/>
+<pad name="CN7_18" x="5.79" y="29.44" drill="1"/>
+<pad name="CN7_16" x="5.79" y="31.98" drill="1"/>
+<pad name="CN7_14" x="5.79" y="34.52" drill="1"/>
+<pad name="CN7_12" x="5.79" y="37.06" drill="1"/>
+<pad name="CN7_10" x="5.79" y="39.6" drill="1"/>
+<pad name="CN7_8" x="5.79" y="42.14" drill="1"/>
+<pad name="CN7_6" x="5.79" y="44.68" drill="1"/>
+<pad name="CN7_4" x="5.79" y="47.22" drill="1"/>
+<pad name="CN7_2" x="5.79" y="49.76" drill="1"/>
+<pad name="CN8_6" x="10.87" y="4.04" drill="1"/>
+<pad name="CN8_4" x="10.87" y="9.12" drill="1"/>
+<pad name="CN8_3" x="10.87" y="11.66" drill="1"/>
+<pad name="CN8_2" x="10.87" y="14.2" drill="1"/>
+<pad name="CN8_1" x="10.87" y="16.74" drill="1" shape="square"/>
+<pad name="CN6_8" x="10.87" y="21.82" drill="1"/>
+<pad name="CN6_7" x="10.87" y="24.36" drill="1"/>
+<pad name="CN8_5" x="10.87" y="6.58" drill="1"/>
+<pad name="CN6_6" x="10.87" y="26.9" drill="1"/>
+<pad name="CN6_5" x="10.87" y="29.44" drill="1"/>
+<pad name="CN6_4" x="10.87" y="31.98" drill="1"/>
+<pad name="CN6_3" x="10.87" y="34.52" drill="1"/>
+<pad name="CN6_2" x="10.87" y="37.06" drill="1"/>
+<pad name="CN6_1" x="10.87" y="39.6" drill="1" shape="square"/>
+<pad name="CN10_36" x="66.75" y="6.58" drill="1"/>
+<pad name="CN10_34" x="66.75" y="9.12" drill="1"/>
+<pad name="CN10_32" x="66.75" y="11.66" drill="1"/>
+<pad name="CN10_30" x="66.75" y="14.2" drill="1"/>
+<pad name="CN10_28" x="66.75" y="16.74" drill="1"/>
+<pad name="CN10_26" x="66.75" y="19.28" drill="1"/>
+<pad name="CN10_24" x="66.75" y="21.82" drill="1"/>
+<pad name="CN10_22" x="66.75" y="24.36" drill="1"/>
+<pad name="CN10_20" x="66.75" y="26.9" drill="1"/>
+<pad name="CN10_18" x="66.75" y="29.44" drill="1"/>
+<pad name="CN10_16" x="66.75" y="31.98" drill="1"/>
+<pad name="CN10_14" x="66.75" y="34.52" drill="1"/>
+<pad name="CN10_12" x="66.75" y="37.06" drill="1"/>
+<pad name="CN10_10" x="66.75" y="39.6" drill="1"/>
+<pad name="CN10_8" x="66.75" y="42.14" drill="1"/>
+<pad name="CN10_6" x="66.75" y="44.68" drill="1"/>
+<pad name="CN10_4" x="66.75" y="47.22" drill="1"/>
+<pad name="CN10_2" x="66.75" y="49.76" drill="1"/>
+<pad name="CN10_37" x="64.21" y="4.04" drill="1"/>
+<pad name="CN10_35" x="64.21" y="6.58" drill="1"/>
+<pad name="CN10_33" x="64.21" y="9.12" drill="1"/>
+<pad name="CN10_31" x="64.21" y="11.66" drill="1"/>
+<pad name="CN10_29" x="64.21" y="14.2" drill="1"/>
+<pad name="CN10_27" x="64.21" y="16.74" drill="1"/>
+<pad name="CN10_25" x="64.21" y="19.28" drill="1"/>
+<pad name="CN10_23" x="64.21" y="21.82" drill="1"/>
+<pad name="CN10_21" x="64.21" y="24.36" drill="1"/>
+<pad name="CN10_19" x="64.21" y="26.9" drill="1"/>
+<pad name="CN10_17" x="64.21" y="29.44" drill="1"/>
+<pad name="CN10_15" x="64.21" y="31.98" drill="1"/>
+<pad name="CN10_13" x="64.21" y="34.52" drill="1"/>
+<pad name="CN10_11" x="64.21" y="37.06" drill="1"/>
+<pad name="CN10_9" x="64.21" y="39.6" drill="1"/>
+<pad name="CN10_7" x="64.21" y="42.14" drill="1"/>
+<pad name="CN10_5" x="64.21" y="44.68" drill="1"/>
+<pad name="CN10_3" x="64.21" y="47.22" drill="1"/>
+<pad name="CN10_1" x="64.21" y="49.76" drill="1" shape="square"/>
+<pad name="CN9_1" x="59.13" y="4.04" drill="1" shape="square"/>
+<pad name="CN9_3" x="59.13" y="9.12" drill="1"/>
+<pad name="CN9_4" x="59.13" y="11.66" drill="1"/>
+<pad name="CN9_5" x="59.13" y="14.2" drill="1"/>
+<pad name="CN9_6" x="59.13" y="16.74" drill="1"/>
+<pad name="CN9_7" x="59.13" y="19.28" drill="1"/>
+<pad name="CN9_8" x="59.13" y="21.82" drill="1"/>
+<pad name="CN9_2" x="59.13" y="6.58" drill="1"/>
+<pad name="CN5_1" x="59.13" y="25.63" drill="1" shape="square"/>
+<pad name="CN5_2" x="59.13" y="28.17" drill="1"/>
+<pad name="CN5_3" x="59.13" y="30.71" drill="1"/>
+<pad name="CN5_4" x="59.13" y="33.25" drill="1"/>
+<pad name="CN5_5" x="59.13" y="35.79" drill="1"/>
+<pad name="CN5_6" x="59.13" y="38.33" drill="1"/>
+<pad name="CN5_7" x="59.13" y="40.87" drill="1"/>
+<pad name="CN5_8" x="59.13" y="43.41" drill="1"/>
+<pad name="CN5_9" x="59.13" y="45.95" drill="1"/>
+<pad name="CN5_10" x="59.13" y="48.49" drill="1"/>
 <wire x1="5.7912" y1="34.5186" x2="10.8712" y2="34.5186" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="37.0586" x2="10.8712" y2="37.0586" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="39.5986" x2="10.8712" y2="39.5986" width="0.127" layer="1"/>
@@ -742,44 +742,56 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="56.5" y1="1" x2="55.5" y2="0" width="0.127" layer="49" curve="-90"/>
 </package>
 <package name="NUCLEO-HEADER">
-<pad name="37" x="22.86" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="35" x="20.32" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="33" x="17.78" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="31" x="15.24" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="29" x="12.7" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="27" x="10.16" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="25" x="7.62" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="23" x="5.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="21" x="2.54" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="19" x="0" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="17" x="-2.54" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="15" x="-5.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="13" x="-7.62" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="11" x="-10.16" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="9" x="-12.7" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="7" x="-15.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="5" x="-17.78" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="3" x="-20.32" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="1" x="-22.86" y="-1.27" drill="0.8" shape="square" rot="R90"/>
-<pad name="38" x="22.86" y="1.27" drill="0.8" rot="R90"/>
-<pad name="36" x="20.32" y="1.27" drill="0.8" rot="R90"/>
-<pad name="34" x="17.78" y="1.27" drill="0.8" rot="R90"/>
-<pad name="32" x="15.24" y="1.27" drill="0.8" rot="R90"/>
-<pad name="30" x="12.7" y="1.27" drill="0.8" rot="R90"/>
-<pad name="28" x="10.16" y="1.27" drill="0.8" rot="R90"/>
-<pad name="26" x="7.62" y="1.27" drill="0.8" rot="R90"/>
-<pad name="24" x="5.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="22" x="2.54" y="1.27" drill="0.8" rot="R90"/>
-<pad name="20" x="0" y="1.27" drill="0.8" rot="R90"/>
-<pad name="18" x="-2.54" y="1.27" drill="0.8" rot="R90"/>
-<pad name="16" x="-5.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="14" x="-7.62" y="1.27" drill="0.8" rot="R90"/>
-<pad name="12" x="-10.16" y="1.27" drill="0.8" rot="R90"/>
-<pad name="10" x="-12.7" y="1.27" drill="0.8" rot="R90"/>
-<pad name="8" x="-15.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="6" x="-17.78" y="1.27" drill="0.8" rot="R90"/>
-<pad name="4" x="-20.32" y="1.27" drill="0.8" rot="R90"/>
-<pad name="2" x="-22.86" y="1.27" drill="0.8" rot="R90"/>
+<pad name="37" x="22.86" y="-1.27" drill="1" rot="R90"/>
+<pad name="35" x="20.32" y="-1.27" drill="1" rot="R90"/>
+<pad name="33" x="17.78" y="-1.27" drill="1" rot="R90"/>
+<pad name="31" x="15.24" y="-1.27" drill="1" rot="R90"/>
+<pad name="29" x="12.7" y="-1.27" drill="1" rot="R90"/>
+<pad name="27" x="10.16" y="-1.27" drill="1" rot="R90"/>
+<pad name="25" x="7.62" y="-1.27" drill="1" rot="R90"/>
+<pad name="23" x="5.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="21" x="2.54" y="-1.27" drill="1" rot="R90"/>
+<pad name="19" x="0" y="-1.27" drill="1" rot="R90"/>
+<pad name="17" x="-2.54" y="-1.27" drill="1" rot="R90"/>
+<pad name="15" x="-5.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="13" x="-7.62" y="-1.27" drill="1" rot="R90"/>
+<pad name="11" x="-10.16" y="-1.27" drill="1" rot="R90"/>
+<pad name="9" x="-12.7" y="-1.27" drill="1" rot="R90"/>
+<pad name="7" x="-15.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="5" x="-17.78" y="-1.27" drill="1" rot="R90"/>
+<pad name="3" x="-20.32" y="-1.27" drill="1" rot="R90"/>
+<pad name="1" x="-22.86" y="-1.27" drill="1" shape="square" rot="R90"/>
+<pad name="38" x="22.86" y="1.27" drill="1" rot="R90"/>
+<pad name="36" x="20.32" y="1.27" drill="1" rot="R90"/>
+<pad name="34" x="17.78" y="1.27" drill="1" rot="R90"/>
+<pad name="32" x="15.24" y="1.27" drill="1" rot="R90"/>
+<pad name="30" x="12.7" y="1.27" drill="1" rot="R90"/>
+<pad name="28" x="10.16" y="1.27" drill="1" rot="R90"/>
+<pad name="26" x="7.62" y="1.27" drill="1" rot="R90"/>
+<pad name="24" x="5.08" y="1.27" drill="1" rot="R90"/>
+<pad name="22" x="2.54" y="1.27" drill="1" rot="R90"/>
+<pad name="20" x="0" y="1.27" drill="1" rot="R90"/>
+<pad name="18" x="-2.54" y="1.27" drill="1" rot="R90"/>
+<pad name="16" x="-5.08" y="1.27" drill="1" rot="R90"/>
+<pad name="14" x="-7.62" y="1.27" drill="1" rot="R90"/>
+<pad name="12" x="-10.16" y="1.27" drill="1" rot="R90"/>
+<pad name="10" x="-12.7" y="1.27" drill="1" rot="R90"/>
+<pad name="8" x="-15.08" y="1.27" drill="1" rot="R90"/>
+<pad name="6" x="-17.78" y="1.27" drill="1" rot="R90"/>
+<pad name="4" x="-20.32" y="1.27" drill="1" rot="R90"/>
+<pad name="2" x="-22.86" y="1.27" drill="1" rot="R90"/>
+<text x="-1.27" y="0" size="2" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<rectangle x1="-24.65" y1="-3.05" x2="24.65" y2="3.05" layer="39"/>
+<circle x="-22.86" y="-3.81" radius="0.15" width="0.3" layer="21"/>
+<wire x1="24.13" y1="-2.54" x2="-22.86" y2="-2.54" width="0.127" layer="51"/>
+<wire x1="-22.86" y1="-2.54" x2="-24.13" y2="-1.27" width="0.127" layer="51"/>
+<wire x1="-24.13" y1="-1.27" x2="-24.13" y2="2.54" width="0.127" layer="51"/>
+<wire x1="-24.13" y1="2.54" x2="24.13" y2="2.54" width="0.127" layer="51"/>
+<wire x1="24.13" y1="2.54" x2="24.13" y2="-2.54" width="0.127" layer="51"/>
+<wire x1="-24.3" y1="2.7" x2="24.3" y2="2.7" width="0.127" layer="21"/>
+<wire x1="24.3" y1="2.7" x2="24.3" y2="-2.7" width="0.127" layer="21"/>
+<wire x1="24.3" y1="-2.7" x2="-24.3" y2="-2.7" width="0.127" layer="21"/>
+<wire x1="-24.3" y1="-2.7" x2="-24.3" y2="2.7" width="0.127" layer="21"/>
 </package>
 <package name="RASPBERRYPI-SHIELD-CONNECTOR">
 <wire x1="-16.165" y1="-0.345" x2="-14.315" y2="-0.345" width="0.127" layer="21"/>


### PR DESCRIPTION
Enlarge 0.8 mm drill holes to 1.0 mm for good fit with pin headers. NUCLEO-HEADER has added silkscreen layer, tDocument layer for creating assembly pictures and keepout layer to prevent components being placed closer than 0.5 mm from part.

DIN 49073-1:2010-02 is not modified, it still has 0.8 mm drill holes.

Please review carefully.
