### PR TITLE
Feature: add generic smd footprints, fix pinheaders

### DIFF
--- a/ELL-i-Boards.lbr
+++ b/ELL-i-Boards.lbr
@@ -279,114 +279,114 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="69" y1="82.5" x2="70" y2="81.5" width="0.127" layer="20" curve="-90"/>
 <wire x1="1" y1="1" x2="0" y2="2" width="0.127" layer="20" curve="-90"/>
 <wire x1="70" y1="2" x2="69" y2="1" width="0.127" layer="20" curve="-90"/>
-<pad name="CN7_37" x="3.25" y="4.04" drill="0.8"/>
-<pad name="CN10_38" x="66.75" y="4.04" drill="0.8"/>
-<pad name="CN7_33" x="3.25" y="9.12" drill="0.8"/>
-<pad name="CN7_31" x="3.25" y="11.66" drill="0.8"/>
-<pad name="CN7_29" x="3.25" y="14.2" drill="0.8"/>
-<pad name="CN7_27" x="3.25" y="16.74" drill="0.8"/>
-<pad name="CN7_25" x="3.25" y="19.28" drill="0.8"/>
-<pad name="CN7_23" x="3.25" y="21.82" drill="0.8"/>
-<pad name="CN7_21" x="3.25" y="24.36" drill="0.8"/>
-<pad name="CN7_35" x="3.25" y="6.58" drill="0.8"/>
-<pad name="CN7_19" x="3.25" y="26.9" drill="0.8"/>
-<pad name="CN7_17" x="3.25" y="29.44" drill="0.8"/>
-<pad name="CN7_15" x="3.25" y="31.98" drill="0.8"/>
-<pad name="CN7_13" x="3.25" y="34.52" drill="0.8"/>
-<pad name="CN7_11" x="3.25" y="37.06" drill="0.8"/>
-<pad name="CN7_9" x="3.25" y="39.6" drill="0.8"/>
-<pad name="CN7_7" x="3.25" y="42.14" drill="0.8"/>
-<pad name="CN7_5" x="3.25" y="44.68" drill="0.8"/>
-<pad name="CN7_3" x="3.25" y="47.22" drill="0.8"/>
-<pad name="CN7_1" x="3.25" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN7_38" x="5.79" y="4.04" drill="0.8"/>
-<pad name="CN7_34" x="5.79" y="9.12" drill="0.8"/>
-<pad name="CN7_32" x="5.79" y="11.66" drill="0.8"/>
-<pad name="CN7_30" x="5.79" y="14.2" drill="0.8"/>
-<pad name="CN7_28" x="5.79" y="16.74" drill="0.8"/>
-<pad name="CN7_26" x="5.79" y="19.28" drill="0.8"/>
-<pad name="CN7_24" x="5.79" y="21.82" drill="0.8"/>
-<pad name="CN7_22" x="5.79" y="24.36" drill="0.8"/>
-<pad name="CN7_36" x="5.79" y="6.58" drill="0.8"/>
-<pad name="CN7_20" x="5.79" y="26.9" drill="0.8"/>
-<pad name="CN7_18" x="5.79" y="29.44" drill="0.8"/>
-<pad name="CN7_16" x="5.79" y="31.98" drill="0.8"/>
-<pad name="CN7_14" x="5.79" y="34.52" drill="0.8"/>
-<pad name="CN7_12" x="5.79" y="37.06" drill="0.8"/>
-<pad name="CN7_10" x="5.79" y="39.6" drill="0.8"/>
-<pad name="CN7_8" x="5.79" y="42.14" drill="0.8"/>
-<pad name="CN7_6" x="5.79" y="44.68" drill="0.8"/>
-<pad name="CN7_4" x="5.79" y="47.22" drill="0.8"/>
-<pad name="CN7_2" x="5.79" y="49.76" drill="0.8"/>
-<pad name="CN8_6" x="10.87" y="4.04" drill="0.8"/>
-<pad name="CN8_4" x="10.87" y="9.12" drill="0.8"/>
-<pad name="CN8_3" x="10.87" y="11.66" drill="0.8"/>
-<pad name="CN8_2" x="10.87" y="14.2" drill="0.8"/>
-<pad name="CN8_1" x="10.87" y="16.74" drill="0.8" shape="square"/>
-<pad name="CN6_8" x="10.87" y="21.82" drill="0.8"/>
-<pad name="CN6_7" x="10.87" y="24.36" drill="0.8"/>
-<pad name="CN8_5" x="10.87" y="6.58" drill="0.8"/>
-<pad name="CN6_6" x="10.87" y="26.9" drill="0.8"/>
-<pad name="CN6_5" x="10.87" y="29.44" drill="0.8"/>
-<pad name="CN6_4" x="10.87" y="31.98" drill="0.8"/>
-<pad name="CN6_3" x="10.87" y="34.52" drill="0.8"/>
-<pad name="CN6_2" x="10.87" y="37.06" drill="0.8"/>
-<pad name="CN6_1" x="10.87" y="39.6" drill="0.8" shape="square"/>
-<pad name="CN10_36" x="66.75" y="6.58" drill="0.8"/>
-<pad name="CN10_34" x="66.75" y="9.12" drill="0.8"/>
-<pad name="CN10_32" x="66.75" y="11.66" drill="0.8"/>
-<pad name="CN10_30" x="66.75" y="14.2" drill="0.8"/>
-<pad name="CN10_28" x="66.75" y="16.74" drill="0.8"/>
-<pad name="CN10_26" x="66.75" y="19.28" drill="0.8"/>
-<pad name="CN10_24" x="66.75" y="21.82" drill="0.8"/>
-<pad name="CN10_22" x="66.75" y="24.36" drill="0.8"/>
-<pad name="CN10_20" x="66.75" y="26.9" drill="0.8"/>
-<pad name="CN10_18" x="66.75" y="29.44" drill="0.8"/>
-<pad name="CN10_16" x="66.75" y="31.98" drill="0.8"/>
-<pad name="CN10_14" x="66.75" y="34.52" drill="0.8"/>
-<pad name="CN10_12" x="66.75" y="37.06" drill="0.8"/>
-<pad name="CN10_10" x="66.75" y="39.6" drill="0.8"/>
-<pad name="CN10_8" x="66.75" y="42.14" drill="0.8"/>
-<pad name="CN10_6" x="66.75" y="44.68" drill="0.8"/>
-<pad name="CN10_4" x="66.75" y="47.22" drill="0.8"/>
-<pad name="CN10_2" x="66.75" y="49.76" drill="0.8"/>
-<pad name="CN10_37" x="64.21" y="4.04" drill="0.8"/>
-<pad name="CN10_35" x="64.21" y="6.58" drill="0.8"/>
-<pad name="CN10_33" x="64.21" y="9.12" drill="0.8"/>
-<pad name="CN10_31" x="64.21" y="11.66" drill="0.8"/>
-<pad name="CN10_29" x="64.21" y="14.2" drill="0.8"/>
-<pad name="CN10_27" x="64.21" y="16.74" drill="0.8"/>
-<pad name="CN10_25" x="64.21" y="19.28" drill="0.8"/>
-<pad name="CN10_23" x="64.21" y="21.82" drill="0.8"/>
-<pad name="CN10_21" x="64.21" y="24.36" drill="0.8"/>
-<pad name="CN10_19" x="64.21" y="26.9" drill="0.8"/>
-<pad name="CN10_17" x="64.21" y="29.44" drill="0.8"/>
-<pad name="CN10_15" x="64.21" y="31.98" drill="0.8"/>
-<pad name="CN10_13" x="64.21" y="34.52" drill="0.8"/>
-<pad name="CN10_11" x="64.21" y="37.06" drill="0.8"/>
-<pad name="CN10_9" x="64.21" y="39.6" drill="0.8"/>
-<pad name="CN10_7" x="64.21" y="42.14" drill="0.8"/>
-<pad name="CN10_5" x="64.21" y="44.68" drill="0.8"/>
-<pad name="CN10_3" x="64.21" y="47.22" drill="0.8"/>
-<pad name="CN10_1" x="64.21" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN9_1" x="59.13" y="4.04" drill="0.8" shape="square"/>
-<pad name="CN9_3" x="59.13" y="9.12" drill="0.8"/>
-<pad name="CN9_4" x="59.13" y="11.66" drill="0.8"/>
-<pad name="CN9_5" x="59.13" y="14.2" drill="0.8"/>
-<pad name="CN9_6" x="59.13" y="16.74" drill="0.8"/>
-<pad name="CN9_7" x="59.13" y="19.28" drill="0.8"/>
-<pad name="CN9_8" x="59.13" y="21.82" drill="0.8"/>
-<pad name="CN9_2" x="59.13" y="6.58" drill="0.8"/>
-<pad name="CN5_1" x="59.13" y="25.63" drill="0.8" shape="square"/>
-<pad name="CN5_2" x="59.13" y="28.17" drill="0.8"/>
-<pad name="CN5_3" x="59.13" y="30.71" drill="0.8"/>
-<pad name="CN5_4" x="59.13" y="33.25" drill="0.8"/>
-<pad name="CN5_5" x="59.13" y="35.79" drill="0.8"/>
-<pad name="CN5_6" x="59.13" y="38.33" drill="0.8"/>
-<pad name="CN5_7" x="59.13" y="40.87" drill="0.8"/>
-<pad name="CN5_8" x="59.13" y="43.41" drill="0.8"/>
-<pad name="CN5_9" x="59.13" y="45.95" drill="0.8"/>
-<pad name="CN5_10" x="59.13" y="48.49" drill="0.8"/>
+<pad name="CN7_37" x="3.25" y="4.04" drill="1"/>
+<pad name="CN10_38" x="66.75" y="4.04" drill="1"/>
+<pad name="CN7_33" x="3.25" y="9.12" drill="1"/>
+<pad name="CN7_31" x="3.25" y="11.66" drill="1"/>
+<pad name="CN7_29" x="3.25" y="14.2" drill="1"/>
+<pad name="CN7_27" x="3.25" y="16.74" drill="1"/>
+<pad name="CN7_25" x="3.25" y="19.28" drill="1"/>
+<pad name="CN7_23" x="3.25" y="21.82" drill="1"/>
+<pad name="CN7_21" x="3.25" y="24.36" drill="1"/>
+<pad name="CN7_35" x="3.25" y="6.58" drill="1"/>
+<pad name="CN7_19" x="3.25" y="26.9" drill="1"/>
+<pad name="CN7_17" x="3.25" y="29.44" drill="1"/>
+<pad name="CN7_15" x="3.25" y="31.98" drill="1"/>
+<pad name="CN7_13" x="3.25" y="34.52" drill="1"/>
+<pad name="CN7_11" x="3.25" y="37.06" drill="1"/>
+<pad name="CN7_9" x="3.25" y="39.6" drill="1"/>
+<pad name="CN7_7" x="3.25" y="42.14" drill="1"/>
+<pad name="CN7_5" x="3.25" y="44.68" drill="1"/>
+<pad name="CN7_3" x="3.25" y="47.22" drill="1"/>
+<pad name="CN7_1" x="3.25" y="49.76" drill="1" shape="square"/>
+<pad name="CN7_38" x="5.79" y="4.04" drill="1"/>
+<pad name="CN7_34" x="5.79" y="9.12" drill="1"/>
+<pad name="CN7_32" x="5.79" y="11.66" drill="1"/>
+<pad name="CN7_30" x="5.79" y="14.2" drill="1"/>
+<pad name="CN7_28" x="5.79" y="16.74" drill="1"/>
+<pad name="CN7_26" x="5.79" y="19.28" drill="1"/>
+<pad name="CN7_24" x="5.79" y="21.82" drill="1"/>
+<pad name="CN7_22" x="5.79" y="24.36" drill="1"/>
+<pad name="CN7_36" x="5.79" y="6.58" drill="1"/>
+<pad name="CN7_20" x="5.79" y="26.9" drill="1"/>
+<pad name="CN7_18" x="5.79" y="29.44" drill="1"/>
+<pad name="CN7_16" x="5.79" y="31.98" drill="1"/>
+<pad name="CN7_14" x="5.79" y="34.52" drill="1"/>
+<pad name="CN7_12" x="5.79" y="37.06" drill="1"/>
+<pad name="CN7_10" x="5.79" y="39.6" drill="1"/>
+<pad name="CN7_8" x="5.79" y="42.14" drill="1"/>
+<pad name="CN7_6" x="5.79" y="44.68" drill="1"/>
+<pad name="CN7_4" x="5.79" y="47.22" drill="1"/>
+<pad name="CN7_2" x="5.79" y="49.76" drill="1"/>
+<pad name="CN8_6" x="10.87" y="4.04" drill="1"/>
+<pad name="CN8_4" x="10.87" y="9.12" drill="1"/>
+<pad name="CN8_3" x="10.87" y="11.66" drill="1"/>
+<pad name="CN8_2" x="10.87" y="14.2" drill="1"/>
+<pad name="CN8_1" x="10.87" y="16.74" drill="1" shape="square"/>
+<pad name="CN6_8" x="10.87" y="21.82" drill="1"/>
+<pad name="CN6_7" x="10.87" y="24.36" drill="1"/>
+<pad name="CN8_5" x="10.87" y="6.58" drill="1"/>
+<pad name="CN6_6" x="10.87" y="26.9" drill="1"/>
+<pad name="CN6_5" x="10.87" y="29.44" drill="1"/>
+<pad name="CN6_4" x="10.87" y="31.98" drill="1"/>
+<pad name="CN6_3" x="10.87" y="34.52" drill="1"/>
+<pad name="CN6_2" x="10.87" y="37.06" drill="1"/>
+<pad name="CN6_1" x="10.87" y="39.6" drill="1" shape="square"/>
+<pad name="CN10_36" x="66.75" y="6.58" drill="1"/>
+<pad name="CN10_34" x="66.75" y="9.12" drill="1"/>
+<pad name="CN10_32" x="66.75" y="11.66" drill="1"/>
+<pad name="CN10_30" x="66.75" y="14.2" drill="1"/>
+<pad name="CN10_28" x="66.75" y="16.74" drill="1"/>
+<pad name="CN10_26" x="66.75" y="19.28" drill="1"/>
+<pad name="CN10_24" x="66.75" y="21.82" drill="1"/>
+<pad name="CN10_22" x="66.75" y="24.36" drill="1"/>
+<pad name="CN10_20" x="66.75" y="26.9" drill="1"/>
+<pad name="CN10_18" x="66.75" y="29.44" drill="1"/>
+<pad name="CN10_16" x="66.75" y="31.98" drill="1"/>
+<pad name="CN10_14" x="66.75" y="34.52" drill="1"/>
+<pad name="CN10_12" x="66.75" y="37.06" drill="1"/>
+<pad name="CN10_10" x="66.75" y="39.6" drill="1"/>
+<pad name="CN10_8" x="66.75" y="42.14" drill="1"/>
+<pad name="CN10_6" x="66.75" y="44.68" drill="1"/>
+<pad name="CN10_4" x="66.75" y="47.22" drill="1"/>
+<pad name="CN10_2" x="66.75" y="49.76" drill="1"/>
+<pad name="CN10_37" x="64.21" y="4.04" drill="1"/>
+<pad name="CN10_35" x="64.21" y="6.58" drill="1"/>
+<pad name="CN10_33" x="64.21" y="9.12" drill="1"/>
+<pad name="CN10_31" x="64.21" y="11.66" drill="1"/>
+<pad name="CN10_29" x="64.21" y="14.2" drill="1"/>
+<pad name="CN10_27" x="64.21" y="16.74" drill="1"/>
+<pad name="CN10_25" x="64.21" y="19.28" drill="1"/>
+<pad name="CN10_23" x="64.21" y="21.82" drill="1"/>
+<pad name="CN10_21" x="64.21" y="24.36" drill="1"/>
+<pad name="CN10_19" x="64.21" y="26.9" drill="1"/>
+<pad name="CN10_17" x="64.21" y="29.44" drill="1"/>
+<pad name="CN10_15" x="64.21" y="31.98" drill="1"/>
+<pad name="CN10_13" x="64.21" y="34.52" drill="1"/>
+<pad name="CN10_11" x="64.21" y="37.06" drill="1"/>
+<pad name="CN10_9" x="64.21" y="39.6" drill="1"/>
+<pad name="CN10_7" x="64.21" y="42.14" drill="1"/>
+<pad name="CN10_5" x="64.21" y="44.68" drill="1"/>
+<pad name="CN10_3" x="64.21" y="47.22" drill="1"/>
+<pad name="CN10_1" x="64.21" y="49.76" drill="1" shape="square"/>
+<pad name="CN9_1" x="59.13" y="4.04" drill="1" shape="square"/>
+<pad name="CN9_3" x="59.13" y="9.12" drill="1"/>
+<pad name="CN9_4" x="59.13" y="11.66" drill="1"/>
+<pad name="CN9_5" x="59.13" y="14.2" drill="1"/>
+<pad name="CN9_6" x="59.13" y="16.74" drill="1"/>
+<pad name="CN9_7" x="59.13" y="19.28" drill="1"/>
+<pad name="CN9_8" x="59.13" y="21.82" drill="1"/>
+<pad name="CN9_2" x="59.13" y="6.58" drill="1"/>
+<pad name="CN5_1" x="59.13" y="25.63" drill="1" shape="square"/>
+<pad name="CN5_2" x="59.13" y="28.17" drill="1"/>
+<pad name="CN5_3" x="59.13" y="30.71" drill="1"/>
+<pad name="CN5_4" x="59.13" y="33.25" drill="1"/>
+<pad name="CN5_5" x="59.13" y="35.79" drill="1"/>
+<pad name="CN5_6" x="59.13" y="38.33" drill="1"/>
+<pad name="CN5_7" x="59.13" y="40.87" drill="1"/>
+<pad name="CN5_8" x="59.13" y="43.41" drill="1"/>
+<pad name="CN5_9" x="59.13" y="45.95" drill="1"/>
+<pad name="CN5_10" x="59.13" y="48.49" drill="1"/>
 <wire x1="5.7912" y1="34.5186" x2="10.8712" y2="34.5186" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="37.0586" x2="10.8712" y2="37.0586" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="39.5986" x2="10.8712" y2="39.5986" width="0.127" layer="1"/>
@@ -539,114 +539,114 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="69" y1="57.5" x2="70" y2="56.5" width="0.127" layer="20" curve="-90"/>
 <wire x1="1" y1="1" x2="0" y2="2" width="0.127" layer="20" curve="-90"/>
 <wire x1="70" y1="2" x2="69" y2="1" width="0.127" layer="20" curve="-90"/>
-<pad name="CN7_37" x="3.25" y="4.04" drill="0.8"/>
-<pad name="CN10_38" x="66.75" y="4.04" drill="0.8"/>
-<pad name="CN7_33" x="3.25" y="9.12" drill="0.8"/>
-<pad name="CN7_31" x="3.25" y="11.66" drill="0.8"/>
-<pad name="CN7_29" x="3.25" y="14.2" drill="0.8"/>
-<pad name="CN7_27" x="3.25" y="16.74" drill="0.8"/>
-<pad name="CN7_25" x="3.25" y="19.28" drill="0.8"/>
-<pad name="CN7_23" x="3.25" y="21.82" drill="0.8"/>
-<pad name="CN7_21" x="3.25" y="24.36" drill="0.8"/>
-<pad name="CN7_35" x="3.25" y="6.58" drill="0.8"/>
-<pad name="CN7_19" x="3.25" y="26.9" drill="0.8"/>
-<pad name="CN7_17" x="3.25" y="29.44" drill="0.8"/>
-<pad name="CN7_15" x="3.25" y="31.98" drill="0.8"/>
-<pad name="CN7_13" x="3.25" y="34.52" drill="0.8"/>
-<pad name="CN7_11" x="3.25" y="37.06" drill="0.8"/>
-<pad name="CN7_9" x="3.25" y="39.6" drill="0.8"/>
-<pad name="CN7_7" x="3.25" y="42.14" drill="0.8"/>
-<pad name="CN7_5" x="3.25" y="44.68" drill="0.8"/>
-<pad name="CN7_3" x="3.25" y="47.22" drill="0.8"/>
-<pad name="CN7_1" x="3.25" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN7_38" x="5.79" y="4.04" drill="0.8"/>
-<pad name="CN7_34" x="5.79" y="9.12" drill="0.8"/>
-<pad name="CN7_32" x="5.79" y="11.66" drill="0.8"/>
-<pad name="CN7_30" x="5.79" y="14.2" drill="0.8"/>
-<pad name="CN7_28" x="5.79" y="16.74" drill="0.8"/>
-<pad name="CN7_26" x="5.79" y="19.28" drill="0.8"/>
-<pad name="CN7_24" x="5.79" y="21.82" drill="0.8"/>
-<pad name="CN7_22" x="5.79" y="24.36" drill="0.8"/>
-<pad name="CN7_36" x="5.79" y="6.58" drill="0.8"/>
-<pad name="CN7_20" x="5.79" y="26.9" drill="0.8"/>
-<pad name="CN7_18" x="5.79" y="29.44" drill="0.8"/>
-<pad name="CN7_16" x="5.79" y="31.98" drill="0.8"/>
-<pad name="CN7_14" x="5.79" y="34.52" drill="0.8"/>
-<pad name="CN7_12" x="5.79" y="37.06" drill="0.8"/>
-<pad name="CN7_10" x="5.79" y="39.6" drill="0.8"/>
-<pad name="CN7_8" x="5.79" y="42.14" drill="0.8"/>
-<pad name="CN7_6" x="5.79" y="44.68" drill="0.8"/>
-<pad name="CN7_4" x="5.79" y="47.22" drill="0.8"/>
-<pad name="CN7_2" x="5.79" y="49.76" drill="0.8"/>
-<pad name="CN8_6" x="10.87" y="4.04" drill="0.8"/>
-<pad name="CN8_4" x="10.87" y="9.12" drill="0.8"/>
-<pad name="CN8_3" x="10.87" y="11.66" drill="0.8"/>
-<pad name="CN8_2" x="10.87" y="14.2" drill="0.8"/>
-<pad name="CN8_1" x="10.87" y="16.74" drill="0.8" shape="square"/>
-<pad name="CN6_8" x="10.87" y="21.82" drill="0.8"/>
-<pad name="CN6_7" x="10.87" y="24.36" drill="0.8"/>
-<pad name="CN8_5" x="10.87" y="6.58" drill="0.8"/>
-<pad name="CN6_6" x="10.87" y="26.9" drill="0.8"/>
-<pad name="CN6_5" x="10.87" y="29.44" drill="0.8"/>
-<pad name="CN6_4" x="10.87" y="31.98" drill="0.8"/>
-<pad name="CN6_3" x="10.87" y="34.52" drill="0.8"/>
-<pad name="CN6_2" x="10.87" y="37.06" drill="0.8"/>
-<pad name="CN6_1" x="10.87" y="39.6" drill="0.8" shape="square"/>
-<pad name="CN10_36" x="66.75" y="6.58" drill="0.8"/>
-<pad name="CN10_34" x="66.75" y="9.12" drill="0.8"/>
-<pad name="CN10_32" x="66.75" y="11.66" drill="0.8"/>
-<pad name="CN10_30" x="66.75" y="14.2" drill="0.8"/>
-<pad name="CN10_28" x="66.75" y="16.74" drill="0.8"/>
-<pad name="CN10_26" x="66.75" y="19.28" drill="0.8"/>
-<pad name="CN10_24" x="66.75" y="21.82" drill="0.8"/>
-<pad name="CN10_22" x="66.75" y="24.36" drill="0.8"/>
-<pad name="CN10_20" x="66.75" y="26.9" drill="0.8"/>
-<pad name="CN10_18" x="66.75" y="29.44" drill="0.8"/>
-<pad name="CN10_16" x="66.75" y="31.98" drill="0.8"/>
-<pad name="CN10_14" x="66.75" y="34.52" drill="0.8"/>
-<pad name="CN10_12" x="66.75" y="37.06" drill="0.8"/>
-<pad name="CN10_10" x="66.75" y="39.6" drill="0.8"/>
-<pad name="CN10_8" x="66.75" y="42.14" drill="0.8"/>
-<pad name="CN10_6" x="66.75" y="44.68" drill="0.8"/>
-<pad name="CN10_4" x="66.75" y="47.22" drill="0.8"/>
-<pad name="CN10_2" x="66.75" y="49.76" drill="0.8"/>
-<pad name="CN10_37" x="64.21" y="4.04" drill="0.8"/>
-<pad name="CN10_35" x="64.21" y="6.58" drill="0.8"/>
-<pad name="CN10_33" x="64.21" y="9.12" drill="0.8"/>
-<pad name="CN10_31" x="64.21" y="11.66" drill="0.8"/>
-<pad name="CN10_29" x="64.21" y="14.2" drill="0.8"/>
-<pad name="CN10_27" x="64.21" y="16.74" drill="0.8"/>
-<pad name="CN10_25" x="64.21" y="19.28" drill="0.8"/>
-<pad name="CN10_23" x="64.21" y="21.82" drill="0.8"/>
-<pad name="CN10_21" x="64.21" y="24.36" drill="0.8"/>
-<pad name="CN10_19" x="64.21" y="26.9" drill="0.8"/>
-<pad name="CN10_17" x="64.21" y="29.44" drill="0.8"/>
-<pad name="CN10_15" x="64.21" y="31.98" drill="0.8"/>
-<pad name="CN10_13" x="64.21" y="34.52" drill="0.8"/>
-<pad name="CN10_11" x="64.21" y="37.06" drill="0.8"/>
-<pad name="CN10_9" x="64.21" y="39.6" drill="0.8"/>
-<pad name="CN10_7" x="64.21" y="42.14" drill="0.8"/>
-<pad name="CN10_5" x="64.21" y="44.68" drill="0.8"/>
-<pad name="CN10_3" x="64.21" y="47.22" drill="0.8"/>
-<pad name="CN10_1" x="64.21" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN9_1" x="59.13" y="4.04" drill="0.8" shape="square"/>
-<pad name="CN9_3" x="59.13" y="9.12" drill="0.8"/>
-<pad name="CN9_4" x="59.13" y="11.66" drill="0.8"/>
-<pad name="CN9_5" x="59.13" y="14.2" drill="0.8"/>
-<pad name="CN9_6" x="59.13" y="16.74" drill="0.8"/>
-<pad name="CN9_7" x="59.13" y="19.28" drill="0.8"/>
-<pad name="CN9_8" x="59.13" y="21.82" drill="0.8"/>
-<pad name="CN9_2" x="59.13" y="6.58" drill="0.8"/>
-<pad name="CN5_1" x="59.13" y="25.63" drill="0.8" shape="square"/>
-<pad name="CN5_2" x="59.13" y="28.17" drill="0.8"/>
-<pad name="CN5_3" x="59.13" y="30.71" drill="0.8"/>
-<pad name="CN5_4" x="59.13" y="33.25" drill="0.8"/>
-<pad name="CN5_5" x="59.13" y="35.79" drill="0.8"/>
-<pad name="CN5_6" x="59.13" y="38.33" drill="0.8"/>
-<pad name="CN5_7" x="59.13" y="40.87" drill="0.8"/>
-<pad name="CN5_8" x="59.13" y="43.41" drill="0.8"/>
-<pad name="CN5_9" x="59.13" y="45.95" drill="0.8"/>
-<pad name="CN5_10" x="59.13" y="48.49" drill="0.8"/>
+<pad name="CN7_37" x="3.25" y="4.04" drill="1"/>
+<pad name="CN10_38" x="66.75" y="4.04" drill="1"/>
+<pad name="CN7_33" x="3.25" y="9.12" drill="1"/>
+<pad name="CN7_31" x="3.25" y="11.66" drill="1"/>
+<pad name="CN7_29" x="3.25" y="14.2" drill="1"/>
+<pad name="CN7_27" x="3.25" y="16.74" drill="1"/>
+<pad name="CN7_25" x="3.25" y="19.28" drill="1"/>
+<pad name="CN7_23" x="3.25" y="21.82" drill="1"/>
+<pad name="CN7_21" x="3.25" y="24.36" drill="1"/>
+<pad name="CN7_35" x="3.25" y="6.58" drill="1"/>
+<pad name="CN7_19" x="3.25" y="26.9" drill="1"/>
+<pad name="CN7_17" x="3.25" y="29.44" drill="1"/>
+<pad name="CN7_15" x="3.25" y="31.98" drill="1"/>
+<pad name="CN7_13" x="3.25" y="34.52" drill="1"/>
+<pad name="CN7_11" x="3.25" y="37.06" drill="1"/>
+<pad name="CN7_9" x="3.25" y="39.6" drill="1"/>
+<pad name="CN7_7" x="3.25" y="42.14" drill="1"/>
+<pad name="CN7_5" x="3.25" y="44.68" drill="1"/>
+<pad name="CN7_3" x="3.25" y="47.22" drill="1"/>
+<pad name="CN7_1" x="3.25" y="49.76" drill="1" shape="square"/>
+<pad name="CN7_38" x="5.79" y="4.04" drill="1"/>
+<pad name="CN7_34" x="5.79" y="9.12" drill="1"/>
+<pad name="CN7_32" x="5.79" y="11.66" drill="1"/>
+<pad name="CN7_30" x="5.79" y="14.2" drill="1"/>
+<pad name="CN7_28" x="5.79" y="16.74" drill="1"/>
+<pad name="CN7_26" x="5.79" y="19.28" drill="1"/>
+<pad name="CN7_24" x="5.79" y="21.82" drill="1"/>
+<pad name="CN7_22" x="5.79" y="24.36" drill="1"/>
+<pad name="CN7_36" x="5.79" y="6.58" drill="1"/>
+<pad name="CN7_20" x="5.79" y="26.9" drill="1"/>
+<pad name="CN7_18" x="5.79" y="29.44" drill="1"/>
+<pad name="CN7_16" x="5.79" y="31.98" drill="1"/>
+<pad name="CN7_14" x="5.79" y="34.52" drill="1"/>
+<pad name="CN7_12" x="5.79" y="37.06" drill="1"/>
+<pad name="CN7_10" x="5.79" y="39.6" drill="1"/>
+<pad name="CN7_8" x="5.79" y="42.14" drill="1"/>
+<pad name="CN7_6" x="5.79" y="44.68" drill="1"/>
+<pad name="CN7_4" x="5.79" y="47.22" drill="1"/>
+<pad name="CN7_2" x="5.79" y="49.76" drill="1"/>
+<pad name="CN8_6" x="10.87" y="4.04" drill="1"/>
+<pad name="CN8_4" x="10.87" y="9.12" drill="1"/>
+<pad name="CN8_3" x="10.87" y="11.66" drill="1"/>
+<pad name="CN8_2" x="10.87" y="14.2" drill="1"/>
+<pad name="CN8_1" x="10.87" y="16.74" drill="1" shape="square"/>
+<pad name="CN6_8" x="10.87" y="21.82" drill="1"/>
+<pad name="CN6_7" x="10.87" y="24.36" drill="1"/>
+<pad name="CN8_5" x="10.87" y="6.58" drill="1"/>
+<pad name="CN6_6" x="10.87" y="26.9" drill="1"/>
+<pad name="CN6_5" x="10.87" y="29.44" drill="1"/>
+<pad name="CN6_4" x="10.87" y="31.98" drill="1"/>
+<pad name="CN6_3" x="10.87" y="34.52" drill="1"/>
+<pad name="CN6_2" x="10.87" y="37.06" drill="1"/>
+<pad name="CN6_1" x="10.87" y="39.6" drill="1" shape="square"/>
+<pad name="CN10_36" x="66.75" y="6.58" drill="1"/>
+<pad name="CN10_34" x="66.75" y="9.12" drill="1"/>
+<pad name="CN10_32" x="66.75" y="11.66" drill="1"/>
+<pad name="CN10_30" x="66.75" y="14.2" drill="1"/>
+<pad name="CN10_28" x="66.75" y="16.74" drill="1"/>
+<pad name="CN10_26" x="66.75" y="19.28" drill="1"/>
+<pad name="CN10_24" x="66.75" y="21.82" drill="1"/>
+<pad name="CN10_22" x="66.75" y="24.36" drill="1"/>
+<pad name="CN10_20" x="66.75" y="26.9" drill="1"/>
+<pad name="CN10_18" x="66.75" y="29.44" drill="1"/>
+<pad name="CN10_16" x="66.75" y="31.98" drill="1"/>
+<pad name="CN10_14" x="66.75" y="34.52" drill="1"/>
+<pad name="CN10_12" x="66.75" y="37.06" drill="1"/>
+<pad name="CN10_10" x="66.75" y="39.6" drill="1"/>
+<pad name="CN10_8" x="66.75" y="42.14" drill="1"/>
+<pad name="CN10_6" x="66.75" y="44.68" drill="1"/>
+<pad name="CN10_4" x="66.75" y="47.22" drill="1"/>
+<pad name="CN10_2" x="66.75" y="49.76" drill="1"/>
+<pad name="CN10_37" x="64.21" y="4.04" drill="1"/>
+<pad name="CN10_35" x="64.21" y="6.58" drill="1"/>
+<pad name="CN10_33" x="64.21" y="9.12" drill="1"/>
+<pad name="CN10_31" x="64.21" y="11.66" drill="1"/>
+<pad name="CN10_29" x="64.21" y="14.2" drill="1"/>
+<pad name="CN10_27" x="64.21" y="16.74" drill="1"/>
+<pad name="CN10_25" x="64.21" y="19.28" drill="1"/>
+<pad name="CN10_23" x="64.21" y="21.82" drill="1"/>
+<pad name="CN10_21" x="64.21" y="24.36" drill="1"/>
+<pad name="CN10_19" x="64.21" y="26.9" drill="1"/>
+<pad name="CN10_17" x="64.21" y="29.44" drill="1"/>
+<pad name="CN10_15" x="64.21" y="31.98" drill="1"/>
+<pad name="CN10_13" x="64.21" y="34.52" drill="1"/>
+<pad name="CN10_11" x="64.21" y="37.06" drill="1"/>
+<pad name="CN10_9" x="64.21" y="39.6" drill="1"/>
+<pad name="CN10_7" x="64.21" y="42.14" drill="1"/>
+<pad name="CN10_5" x="64.21" y="44.68" drill="1"/>
+<pad name="CN10_3" x="64.21" y="47.22" drill="1"/>
+<pad name="CN10_1" x="64.21" y="49.76" drill="1" shape="square"/>
+<pad name="CN9_1" x="59.13" y="4.04" drill="1" shape="square"/>
+<pad name="CN9_3" x="59.13" y="9.12" drill="1"/>
+<pad name="CN9_4" x="59.13" y="11.66" drill="1"/>
+<pad name="CN9_5" x="59.13" y="14.2" drill="1"/>
+<pad name="CN9_6" x="59.13" y="16.74" drill="1"/>
+<pad name="CN9_7" x="59.13" y="19.28" drill="1"/>
+<pad name="CN9_8" x="59.13" y="21.82" drill="1"/>
+<pad name="CN9_2" x="59.13" y="6.58" drill="1"/>
+<pad name="CN5_1" x="59.13" y="25.63" drill="1" shape="square"/>
+<pad name="CN5_2" x="59.13" y="28.17" drill="1"/>
+<pad name="CN5_3" x="59.13" y="30.71" drill="1"/>
+<pad name="CN5_4" x="59.13" y="33.25" drill="1"/>
+<pad name="CN5_5" x="59.13" y="35.79" drill="1"/>
+<pad name="CN5_6" x="59.13" y="38.33" drill="1"/>
+<pad name="CN5_7" x="59.13" y="40.87" drill="1"/>
+<pad name="CN5_8" x="59.13" y="43.41" drill="1"/>
+<pad name="CN5_9" x="59.13" y="45.95" drill="1"/>
+<pad name="CN5_10" x="59.13" y="48.49" drill="1"/>
 <wire x1="5.7912" y1="34.5186" x2="10.8712" y2="34.5186" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="37.0586" x2="10.8712" y2="37.0586" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="39.5986" x2="10.8712" y2="39.5986" width="0.127" layer="1"/>
@@ -742,44 +742,56 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="56.5" y1="1" x2="55.5" y2="0" width="0.127" layer="49" curve="-90"/>
 </package>
 <package name="NUCLEO-HEADER">
-<pad name="37" x="22.86" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="35" x="20.32" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="33" x="17.78" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="31" x="15.24" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="29" x="12.7" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="27" x="10.16" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="25" x="7.62" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="23" x="5.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="21" x="2.54" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="19" x="0" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="17" x="-2.54" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="15" x="-5.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="13" x="-7.62" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="11" x="-10.16" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="9" x="-12.7" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="7" x="-15.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="5" x="-17.78" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="3" x="-20.32" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="1" x="-22.86" y="-1.27" drill="0.8" shape="square" rot="R90"/>
-<pad name="38" x="22.86" y="1.27" drill="0.8" rot="R90"/>
-<pad name="36" x="20.32" y="1.27" drill="0.8" rot="R90"/>
-<pad name="34" x="17.78" y="1.27" drill="0.8" rot="R90"/>
-<pad name="32" x="15.24" y="1.27" drill="0.8" rot="R90"/>
-<pad name="30" x="12.7" y="1.27" drill="0.8" rot="R90"/>
-<pad name="28" x="10.16" y="1.27" drill="0.8" rot="R90"/>
-<pad name="26" x="7.62" y="1.27" drill="0.8" rot="R90"/>
-<pad name="24" x="5.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="22" x="2.54" y="1.27" drill="0.8" rot="R90"/>
-<pad name="20" x="0" y="1.27" drill="0.8" rot="R90"/>
-<pad name="18" x="-2.54" y="1.27" drill="0.8" rot="R90"/>
-<pad name="16" x="-5.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="14" x="-7.62" y="1.27" drill="0.8" rot="R90"/>
-<pad name="12" x="-10.16" y="1.27" drill="0.8" rot="R90"/>
-<pad name="10" x="-12.7" y="1.27" drill="0.8" rot="R90"/>
-<pad name="8" x="-15.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="6" x="-17.78" y="1.27" drill="0.8" rot="R90"/>
-<pad name="4" x="-20.32" y="1.27" drill="0.8" rot="R90"/>
-<pad name="2" x="-22.86" y="1.27" drill="0.8" rot="R90"/>
+<pad name="37" x="22.86" y="-1.27" drill="1" rot="R90"/>
+<pad name="35" x="20.32" y="-1.27" drill="1" rot="R90"/>
+<pad name="33" x="17.78" y="-1.27" drill="1" rot="R90"/>
+<pad name="31" x="15.24" y="-1.27" drill="1" rot="R90"/>
+<pad name="29" x="12.7" y="-1.27" drill="1" rot="R90"/>
+<pad name="27" x="10.16" y="-1.27" drill="1" rot="R90"/>
+<pad name="25" x="7.62" y="-1.27" drill="1" rot="R90"/>
+<pad name="23" x="5.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="21" x="2.54" y="-1.27" drill="1" rot="R90"/>
+<pad name="19" x="0" y="-1.27" drill="1" rot="R90"/>
+<pad name="17" x="-2.54" y="-1.27" drill="1" rot="R90"/>
+<pad name="15" x="-5.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="13" x="-7.62" y="-1.27" drill="1" rot="R90"/>
+<pad name="11" x="-10.16" y="-1.27" drill="1" rot="R90"/>
+<pad name="9" x="-12.7" y="-1.27" drill="1" rot="R90"/>
+<pad name="7" x="-15.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="5" x="-17.78" y="-1.27" drill="1" rot="R90"/>
+<pad name="3" x="-20.32" y="-1.27" drill="1" rot="R90"/>
+<pad name="1" x="-22.86" y="-1.27" drill="1" shape="square" rot="R90"/>
+<pad name="38" x="22.86" y="1.27" drill="1" rot="R90"/>
+<pad name="36" x="20.32" y="1.27" drill="1" rot="R90"/>
+<pad name="34" x="17.78" y="1.27" drill="1" rot="R90"/>
+<pad name="32" x="15.24" y="1.27" drill="1" rot="R90"/>
+<pad name="30" x="12.7" y="1.27" drill="1" rot="R90"/>
+<pad name="28" x="10.16" y="1.27" drill="1" rot="R90"/>
+<pad name="26" x="7.62" y="1.27" drill="1" rot="R90"/>
+<pad name="24" x="5.08" y="1.27" drill="1" rot="R90"/>
+<pad name="22" x="2.54" y="1.27" drill="1" rot="R90"/>
+<pad name="20" x="0" y="1.27" drill="1" rot="R90"/>
+<pad name="18" x="-2.54" y="1.27" drill="1" rot="R90"/>
+<pad name="16" x="-5.08" y="1.27" drill="1" rot="R90"/>
+<pad name="14" x="-7.62" y="1.27" drill="1" rot="R90"/>
+<pad name="12" x="-10.16" y="1.27" drill="1" rot="R90"/>
+<pad name="10" x="-12.7" y="1.27" drill="1" rot="R90"/>
+<pad name="8" x="-15.08" y="1.27" drill="1" rot="R90"/>
+<pad name="6" x="-17.78" y="1.27" drill="1" rot="R90"/>
+<pad name="4" x="-20.32" y="1.27" drill="1" rot="R90"/>
+<pad name="2" x="-22.86" y="1.27" drill="1" rot="R90"/>
+<text x="-1.27" y="0" size="2" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<rectangle x1="-24.65" y1="-3.05" x2="24.65" y2="3.05" layer="39"/>
+<circle x="-22.86" y="-3.81" radius="0.15" width="0.3" layer="21"/>
+<wire x1="24.13" y1="-2.54" x2="-22.86" y2="-2.54" width="0.127" layer="51"/>
+<wire x1="-22.86" y1="-2.54" x2="-24.13" y2="-1.27" width="0.127" layer="51"/>
+<wire x1="-24.13" y1="-1.27" x2="-24.13" y2="2.54" width="0.127" layer="51"/>
+<wire x1="-24.13" y1="2.54" x2="24.13" y2="2.54" width="0.127" layer="51"/>
+<wire x1="24.13" y1="2.54" x2="24.13" y2="-2.54" width="0.127" layer="51"/>
+<wire x1="-24.3" y1="2.7" x2="24.3" y2="2.7" width="0.127" layer="21"/>
+<wire x1="24.3" y1="2.7" x2="24.3" y2="-2.7" width="0.127" layer="21"/>
+<wire x1="24.3" y1="-2.7" x2="-24.3" y2="-2.7" width="0.127" layer="21"/>
+<wire x1="-24.3" y1="-2.7" x2="-24.3" y2="2.7" width="0.127" layer="21"/>
 </package>
 <package name="RASPBERRYPI-SHIELD-CONNECTOR">
 <wire x1="-16.165" y1="-0.345" x2="-14.315" y2="-0.345" width="0.127" layer="21"/>

--- a/ELL-i-DiscreteSemi.lbr
+++ b/ELL-i-DiscreteSemi.lbr
@@ -385,6 +385,47 @@ Source: http://www.onsemi.com/pub_link/Collateral/MBRA340T3-D.PDF</description>
 <rectangle x1="-2.7432" y1="-3.6576" x2="-1.8796" y2="-1.8034" layer="51"/>
 <rectangle x1="1.8796" y1="-3.6576" x2="2.7432" y2="-1.8034" layer="51"/>
 </package>
+<package name="MLP8L33_HS">
+<description>&lt;h3&gt;MLP8L33&lt;/h3&gt;
+&lt;p&gt;
+Footprint with extended pads for handsoldering. &lt;a href="http://www.fairchildsemi.com/package/packageDetails.html?id=PN_MLOEU-008"&gt;Package web page&lt;/a&gt;
+&lt;/p&gt;</description>
+<wire x1="-1.45" y1="1.65" x2="-1.3" y2="1.65" width="0.1016" layer="21"/>
+<wire x1="-1.3" y1="1.65" x2="1.3" y2="1.65" width="0.1016" layer="51"/>
+<wire x1="1.3" y1="1.65" x2="1.45" y2="1.65" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="1.65" x2="1.45" y2="0.3625" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="0.3625" x2="1.45" y2="-0.375" width="0.1016" layer="51"/>
+<wire x1="1.45" y1="-0.3625" x2="1.45" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="-1.65" x2="1.3" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="1.3" y1="-1.65" x2="-1.3" y2="-1.65" width="0.1016" layer="51"/>
+<wire x1="-1.3" y1="-1.65" x2="-1.45" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="-1.45" y1="-1.65" x2="-1.45" y2="-0.3625" width="0.1016" layer="21"/>
+<wire x1="-1.45" y1="-0.3625" x2="-1.45" y2="0.3625" width="0.1016" layer="51"/>
+<wire x1="-1.45" y1="0.3625" x2="-1.45" y2="1.65" width="0.1016" layer="21"/>
+<circle x="-1.2" y="-1.075" radius="0.125" width="0" layer="21"/>
+<smd name="1" x="-0.975" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="2" x="-0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="3" x="0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="4" x="0.975" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="5" x="0.975" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="6" x="0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="7" x="-0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="8" x="-0.975" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<text x="-1.27" y="1.87" size="0.6096" layer="25">&gt;NAME</text>
+<text x="-1.37" y="-2.505" size="0.6096" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.1375" y1="1.275" x2="-0.8125" y2="1.725" layer="51"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="0.1625" y1="1.275" x2="0.4875" y2="1.725" layer="51"/>
+<rectangle x1="0.8125" y1="1.275" x2="1.1375" y2="1.725" layer="51"/>
+<rectangle x1="0.8125" y1="-1.725" x2="1.1375" y2="-1.275" layer="51"/>
+<rectangle x1="0.1625" y1="-1.725" x2="0.4875" y2="-1.275" layer="51"/>
+<rectangle x1="-0.4875" y1="-1.725" x2="-0.1625" y2="-1.275" layer="51"/>
+<rectangle x1="-1.1375" y1="-1.725" x2="-0.8125" y2="-1.275" layer="51"/>
+<smd name="F1" x="0" y="0.45" dx="2.37" dy="1.7" layer="1"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="0.1325" y1="1.275" x2="0.4575" y2="1.725" layer="51"/>
+</package>
 </packages>
 <symbols>
 <symbol name="DIODE-SCHOTTKY">

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -982,7 +982,7 @@ See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-
 <wire x1="0.9" y1="0.6" x2="0.9" y2="-0.6" width="0.127" layer="47"/>
 <wire x1="-0.5" y1="0.85" x2="0.5" y2="0.85" width="0.127" layer="21"/>
 <wire x1="0.5" y1="-0.85" x2="-0.5" y2="-0.85" width="0.127" layer="21"/>
-<rectangle x1="-2" y1="-1.15" x2="2" y2="1.15" layer="41"/>
+<rectangle x1="-2" y1="-1.15" x2="2" y2="1.15" layer="39"/>
 <wire x1="1.9" y1="1" x2="-1.9" y2="1" width="0.127" layer="51"/>
 <wire x1="-1.9" y1="1" x2="-1.9" y2="-1" width="0.127" layer="51"/>
 <wire x1="-1.9" y1="-1" x2="1.9" y2="-1" width="0.127" layer="51"/>
@@ -1024,7 +1024,7 @@ See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-
 <wire x1="-1.3" y1="-0.8" x2="-1.6" y2="-0.8" width="0.15" layer="47"/>
 <wire x1="-1.3" y1="-0.8" x2="-1.3" y2="0.8" width="0.15" layer="47"/>
 <wire x1="1.3" y1="0.8" x2="1.3" y2="-0.8" width="0.15" layer="47"/>
-<rectangle x1="-2.6" y1="-1.35" x2="2.6" y2="1.35" layer="41"/>
+<rectangle x1="-2.6" y1="-1.35" x2="2.6" y2="1.35" layer="39"/>
 <wire x1="-2.5" y1="1.25" x2="2.5" y2="1.25" width="0.15" layer="51"/>
 <wire x1="2.5" y1="1.25" x2="2.5" y2="-1.25" width="0.15" layer="51"/>
 <wire x1="2.5" y1="-1.25" x2="-2.5" y2="-1.25" width="0.15" layer="51"/>

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.0">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -1156,6 +1156,42 @@ This could be a discrete test loop or just a bare copper pad.</description>
 <technology name=""/>
 </technologies>
 </device>
+<device name="0402-B" package="SMD0402-B">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603-A" package="SMD0603-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805-A" package="SMD0805-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="1206-A" package="SMD1206-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
 </devices>
 </deviceset>
 <deviceset name="C" prefix="C" uservalue="yes">
@@ -1210,6 +1246,42 @@ This could be a discrete test loop or just a bare copper pad.</description>
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0402-B" package="SMD0402-B">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603-A" package="SMD0603-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805-A" package="SMD0805-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="1206-A" package="SMD1206-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -866,6 +866,130 @@ Not reviewed.
 <rectangle x1="0.9517" y1="-0.8491" x2="1.7018" y2="0.8509" layer="51"/>
 <rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
 </package>
+<package name="SMD0402-B">
+<description>&lt;h3&gt;IEC 7351 0402 (1005) - nominal&lt;/h3&gt;
+&lt;p&gt;
+Unpolarised SMD 0402 (1005 metric) footprint, variant B. 
+Pads are considered as nominal (tolerances are not accounted) to keep pads at reasonable size. 
+&lt;/p&gt;
+
+&lt;p&gt;
+Center of pads is at &amp;plusmn;0.5 mm, pad size is 0.35 mm toe and heel, 0.05 mm side. Placement courtyard (keepout area) area is 0.25 mm from pads. Silkscreen has 0.12 mm width, refdes has height of 1.2 mm. Silkscreen is intentionally 0.18 mm away from pads instead of recommended 0.12 mm to keep silkscreen clear of soldermask opening.  Refdes is in center of component and must be placed outside component or deleted after layout has been confirmed. Assembly picture outline is drawn at placement courtyard with line width of 0.12 mm.
+&lt;/p&gt;
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;
+Silkscreen is in tPlace layer.
+&lt;/li&gt;
+&lt;li&gt;
+Refdes for silkscreen is in tNames layer.
+&lt;/li&gt;
+&lt;li&gt;
+Assembly picture (incl. refdes) is in tDocu layer
+&lt;/li&gt;
+&lt;li&gt;
+3D outline is in Measure layer.
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;
+
+&lt;p&gt; Please see &lt;a href = "http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt; this document &lt;/a&gt; for details.
+&lt;/p&gt;</description>
+<wire x1="-0.245" y1="0.219" x2="0.245" y2="0.219" width="0.06" layer="47"/>
+<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.06" layer="47"/>
+<smd name="1" x="-0.5" y="0" dx="0.7" dy="0.6" layer="1" roundness="10"/>
+<smd name="2" x="0.5" y="0" dx="0.7" dy="0.6" layer="1" roundness="10"/>
+<rectangle x1="-0.5" y1="-0.25" x2="-0.25" y2="0.25" layer="47"/>
+<rectangle x1="0.25" y1="-0.25" x2="0.5" y2="0.25" layer="47"/>
+<rectangle x1="-1.1" y1="-0.55" x2="1.1" y2="0.55" layer="39"/>
+<text x="0" y="0" size="1.2" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="0.3" y1="0.48" x2="-0.3" y2="0.48" width="0.127" layer="21"/>
+<wire x1="-0.3" y1="-0.48" x2="0.3" y2="-0.48" width="0.127" layer="21"/>
+<wire x1="-1.04" y1="0.49" x2="1.04" y2="0.49" width="0.127" layer="51"/>
+<wire x1="1.04" y1="0.49" x2="1.04" y2="-0.49" width="0.127" layer="51"/>
+<wire x1="1.04" y1="-0.49" x2="-1.04" y2="-0.49" width="0.127" layer="51"/>
+<wire x1="-1.04" y1="-0.49" x2="-1.04" y2="0.49" width="0.127" layer="51"/>
+<text x="0" y="0" size="0.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+</package>
+<package name="SMD0603-A">
+<description>&lt;h3&gt;IPC-7351-C compliant smd 0603 (1608 metric) footprint, variant A&lt;/h3&gt;
+&lt;p&gt;
+Variant A has large pads and placement courtyard, ideal for handsoldering. Footprint might cause tombstoning on reflow soldering process due to large pads compared to component size. This footprint should be selected only for sparsely populated designs and designs where joint needs to be robust.
+&lt;/p&gt;
+&lt;p&gt;
+Origin is in middle of component, pin 1 is at left. Component is not polarized
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.55 mm toes, 0.45 mm heels and 0.05 mm sides. Tolerances of body dimensions are not considered to keep footprint at reasonable size, and width of component pad is considered to be 0. Pad size is 1.0 * 0.9 mm. 
+&lt;/p&gt;
+&lt;p&gt;
+Silkscreen has 0.15 mm clearance from pads and 0.15 mm width. Name is printed on silkscreen on layer tNames, 0.15 mm width and 1.5 mm height. 
+&lt;/p&gt;
+&lt;p&gt;
+Component has placement courtyard of 0.5 mm from pads. 
+tDocument layer is used for assembly drawing.
+Component outline is drawn on measures layer.
+&lt;/p&gt;</description>
+<smd name="P$1" x="-0.8" y="0" dx="1" dy="0.9" layer="1" roundness="10"/>
+<smd name="P$2" x="0.8" y="0" dx="1" dy="0.9" layer="1" roundness="10"/>
+<wire x1="-0.7" y1="-0.2" x2="-0.7" y2="0.2" width="0.4" layer="47"/>
+<wire x1="0.7" y1="0.2" x2="0.7" y2="-0.2" width="0.4" layer="47"/>
+<wire x1="-0.7" y1="0.3" x2="0.7" y2="0.3" width="0.2" layer="47"/>
+<wire x1="0.7" y1="-0.3" x2="-0.7" y2="-0.3" width="0.2" layer="47"/>
+<rectangle x1="-1.8" y1="-0.95" x2="1.8" y2="0.95" layer="39"/>
+<wire x1="-1.7" y1="-0.9" x2="-1.7" y2="0.9" width="0.1" layer="51"/>
+<wire x1="-1.7" y1="0.9" x2="1.7" y2="0.9" width="0.1" layer="51"/>
+<wire x1="1.7" y1="0.9" x2="1.7" y2="-0.9" width="0.1" layer="51"/>
+<wire x1="1.7" y1="-0.9" x2="-1.7" y2="-0.9" width="0.1" layer="51"/>
+<text x="0" y="0" size="0.8" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="0.6" y1="0.65" x2="-0.6" y2="0.65" width="0.15" layer="21"/>
+<wire x1="-0.6" y1="-0.65" x2="0.6" y2="-0.65" width="0.15" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+</package>
+<package name="SMD0805-A">
+<description>&lt;h3&gt;IPC-7351-C compliant smd 0805 (2012 metric) footprint, variant A&lt;/h3&gt;
+&lt;p&gt;
+Variant A has large pads and placement courtyard, ideal for handsoldering. This footprint should be selected only for sparsely populated designs and designs where joint needs to be robust.
+&lt;/p&gt;
+&lt;p&gt;
+Origin is in middle of component, pin 1 is at left. Component is not polarized
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.55 mm toes, 0.45 mm heels and 0.05 mm sides. Tolerances of body dimensions are not considered to keep footprint at reasonable size, and width of component pad is considered to be 0. Pad size is 1.0 * 1.3 mm. 
+&lt;/p&gt;
+&lt;p&gt;
+Silkscreen has 0.15 mm clearance from pads and 0.15 mm width. Name is printed on silkscreen on layer tNames, 0.15 mm width and 1.5 mm height. 
+&lt;/p&gt;
+&lt;p&gt;
+Component has placement courtyard of 0.5 mm from pads. 
+tDocument layer is used for assembly drawing.
+Component outline is drawn on measures layer.
+&lt;/p&gt;
+&lt;p&gt;
+See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-perfection-starts-in-the-cad-library-part-12/"&gt;mentor blog&lt;/a&gt; and &lt;a href ="http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt;PCB libraries presentation&lt;/a&gt; for reference.
+&lt;/p&gt;</description>
+<smd name="P$1" x="-1" y="0" dx="1" dy="1.3" layer="1"/>
+<smd name="P$2" x="1" y="0" dx="1" dy="1.3" layer="1"/>
+<wire x1="-1" y1="-0.6" x2="-1" y2="0.6" width="0.127" layer="47"/>
+<wire x1="-1" y1="0.6" x2="-0.9" y2="0.6" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="0.6" x2="0.9" y2="0.6" width="0.127" layer="47"/>
+<wire x1="0.9" y1="0.6" x2="1" y2="0.6" width="0.127" layer="47"/>
+<wire x1="1" y1="0.6" x2="1" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="1" y1="-0.6" x2="0.9" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="0.9" y1="-0.6" x2="-0.9" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="-0.6" x2="-1" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="-0.6" x2="-0.9" y2="0.6" width="0.127" layer="47"/>
+<wire x1="0.9" y1="0.6" x2="0.9" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="0.85" x2="0.5" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.85" x2="-0.5" y2="-0.85" width="0.127" layer="21"/>
+<rectangle x1="-2" y1="-1.15" x2="2" y2="1.15" layer="41"/>
+<wire x1="1.9" y1="1" x2="-1.9" y2="1" width="0.127" layer="51"/>
+<wire x1="-1.9" y1="1" x2="-1.9" y2="-1" width="0.127" layer="51"/>
+<wire x1="-1.9" y1="-1" x2="1.9" y2="-1" width="0.127" layer="51"/>
+<wire x1="1.9" y1="-1" x2="1.9" y2="1" width="0.127" layer="51"/>
+<text x="0" y="0" size="0.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+</package>
 </packages>
 <symbols>
 <symbol name="R_EU">

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -990,6 +990,50 @@ See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-
 <text x="0" y="0" size="0.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
 <text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
 </package>
+<package name="SMD1206-A">
+<description>&lt;h3&gt;IPC-7351-C compliant smd 1206 (3216 metric) footprint, variant A&lt;/h3&gt;
+&lt;p&gt;
+Variant A has large pads and placement courtyard, ideal for handsoldering. This footprint should be selected only for sparsely populated designs and designs where joint needs to be robust.
+&lt;/p&gt;
+&lt;p&gt;
+Origin is in middle of the component, pin 1 is at left. Component is not polarized.
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.55 mm toes, 0.45 mm heels and 0.05 mm sides. Tolerances of body dimensions are not considered to keep footprint at reasonable size, and width of component pad is considered to be 0. Pad size is 1.0 * 1.7 mm. 
+&lt;/p&gt;
+&lt;p&gt;
+Silkscreen has 0.15 mm clearance from pads and 0.15 mm width. Name is printed on silkscreen on layer tNames, 0.15 mm width and 1.5 mm height. 
+&lt;/p&gt;
+&lt;p&gt;
+Component has placement courtyard of 0.5 mm from pads. 
+tDocument layer is used for assembly drawing.
+Component outline is drawn on measures layer.
+&lt;/p&gt;
+&lt;p&gt;
+See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-perfection-starts-in-the-cad-library-part-12/"&gt;mentor blog&lt;/a&gt; and &lt;a href ="http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt;PCB libraries presentation&lt;/a&gt; for reference.
+&lt;/p&gt;</description>
+<smd name="P$1" x="-1.6" y="0" dx="1" dy="1.7" layer="1"/>
+<smd name="P$2" x="1.6" y="0" dx="1" dy="1.7" layer="1"/>
+<wire x1="-1.6" y1="-0.8" x2="-1.6" y2="0.8" width="0.15" layer="47"/>
+<wire x1="-1.6" y1="0.8" x2="-1.3" y2="0.8" width="0.15" layer="47"/>
+<wire x1="-1.3" y1="0.8" x2="1.3" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.3" y1="0.8" x2="1.6" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.6" y1="0.8" x2="1.6" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="1.6" y1="-0.8" x2="1.3" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="1.3" y1="-0.8" x2="-1.3" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="-1.3" y1="-0.8" x2="-1.6" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="-1.3" y1="-0.8" x2="-1.3" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.3" y1="0.8" x2="1.3" y2="-0.8" width="0.15" layer="47"/>
+<rectangle x1="-2.6" y1="-1.35" x2="2.6" y2="1.35" layer="41"/>
+<wire x1="-2.5" y1="1.25" x2="2.5" y2="1.25" width="0.15" layer="51"/>
+<wire x1="2.5" y1="1.25" x2="2.5" y2="-1.25" width="0.15" layer="51"/>
+<wire x1="2.5" y1="-1.25" x2="-2.5" y2="-1.25" width="0.15" layer="51"/>
+<wire x1="-2.5" y1="-1.25" x2="-2.5" y2="1.25" width="0.15" layer="51"/>
+<text x="0" y="0" size="1" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="1.2" y1="1.1" x2="-1.2" y2="1.1" width="0.15" layer="21"/>
+<wire x1="-1.2" y1="-1.1" x2="1.2" y2="-1.1" width="0.15" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" ratio="10" align="center">&gt;NAME</text>
+</package>
 </packages>
 <symbols>
 <symbol name="R_EU">


### PR DESCRIPTION
Fixes the 0.8 mm drill holes in nucleop pin headers, new size is 1.0 mm.

Adds generic footprints with consistent silkscreen, mechanical drawing and assembly picture layers.
A-variants have 0.5 mm placement courtyard.
Pads of A-variants have 0.5 mm toes, 0.45 mm heels and 0.05 mm sides. 
Silkscreen is on tPlace layer, and has linewidth of 0.15mm and clearence of 0.15 mm from pads. 
Assembly drawing is on tDocu layer, mechanical drawing is on Measures layer.
Names of parts are both in tDocu and tNames layers. tNames (silkscreen) has 1.5 mm height, 10 % ratio.
assembly drawing name size is scaled to fit within placement couryard of part.
