### PR TITLE
PoElli 1.0 parts

### DIFF
--- a/ELL-i-Boards.lbr
+++ b/ELL-i-Boards.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.0">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -792,6 +792,7 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="24.3" y1="2.7" x2="24.3" y2="-2.7" width="0.127" layer="21"/>
 <wire x1="24.3" y1="-2.7" x2="-24.3" y2="-2.7" width="0.127" layer="21"/>
 <wire x1="-24.3" y1="-2.7" x2="-24.3" y2="2.7" width="0.127" layer="21"/>
+<text x="0.00" y="-0.00" size="1.5" layer="27" font="vector" ratio="10" align="center">&gt;NAME</text>
 </package>
 <package name="RASPBERRYPI-SHIELD-CONNECTOR">
 <wire x1="-16.165" y1="-0.345" x2="-14.315" y2="-0.345" width="0.127" layer="21"/>
@@ -838,6 +839,117 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <text x="-10.6614" y="2.9089" size="0.4064" layer="51">GND</text>
 <text x="19.02" y="-0.77" size="1.27" layer="21" ratio="10" rot="R180">25</text>
 <pad name="19" x="7.62" y="-1.27" drill="1"/>
+</package>
+<package name="NUCLEO-SHIELD-UNDERSIDE-SHORT-20-PINHEADER">
+<description>&lt;h3&gt;Nucleo shield template with 2*20 pin headers&lt;/h3&gt;
+&lt;p&gt;
+This version of shield has no Arduino headers and it has 2*20 pin headers because they're easier to source than Morpho's 2*19 pin headers.</description>
+<wire x1="-22.8" y1="-26.74" x2="10.2" y2="-26.74" width="0.127" layer="20"/>
+<wire x1="-22.8" y1="-26.74" x2="-23.8" y2="-25.74" width="0.127" layer="20"/>
+<wire x1="-23.8" y1="-25.74" x2="-33.8" y2="-25.74" width="0.127" layer="20"/>
+<wire x1="-34.8" y1="-24.74" x2="-34.8" y2="29.76" width="0.127" layer="20"/>
+<wire x1="-33.8" y1="30.76" x2="34.2" y2="30.76" width="0.127" layer="20"/>
+<wire x1="35.2" y1="-24.74" x2="35.2" y2="29.76" width="0.127" layer="20"/>
+<wire x1="34.2" y1="-25.74" x2="11.2" y2="-25.74" width="0.127" layer="20"/>
+<wire x1="10.2" y1="-26.74" x2="11.2" y2="-25.74" width="0.127" layer="20"/>
+<wire x1="-34.8" y1="29.76" x2="-33.8" y2="30.76" width="0.127" layer="20" curve="-90"/>
+<wire x1="34.2" y1="30.76" x2="35.2" y2="29.76" width="0.127" layer="20" curve="-90"/>
+<wire x1="-33.8" y1="-25.74" x2="-34.8" y2="-24.74" width="0.127" layer="20" curve="-90"/>
+<wire x1="35.2" y1="-24.74" x2="34.2" y2="-25.74" width="0.127" layer="20" curve="-90"/>
+<pad name="CN7_37" x="-31.55" y="-22.7" drill="1"/>
+<pad name="CN10_38" x="31.95" y="-22.7" drill="1"/>
+<pad name="CN7_33" x="-31.55" y="-17.62" drill="1"/>
+<pad name="CN7_31" x="-31.55" y="-15.08" drill="1"/>
+<pad name="CN7_29" x="-31.55" y="-12.54" drill="1"/>
+<pad name="CN7_27" x="-31.55" y="-10" drill="1"/>
+<pad name="CN7_25" x="-31.55" y="-7.46" drill="1"/>
+<pad name="CN7_23" x="-31.55" y="-4.92" drill="1"/>
+<pad name="CN7_21" x="-31.55" y="-2.38" drill="1"/>
+<pad name="CN7_35" x="-31.55" y="-20.16" drill="1"/>
+<pad name="CN7_19" x="-31.55" y="0.16" drill="1"/>
+<pad name="CN7_17" x="-31.55" y="2.7" drill="1"/>
+<pad name="CN7_15" x="-31.55" y="5.24" drill="1"/>
+<pad name="CN7_13" x="-31.55" y="7.78" drill="1"/>
+<pad name="CN7_11" x="-31.55" y="10.32" drill="1"/>
+<pad name="CN7_9" x="-31.55" y="12.86" drill="1"/>
+<pad name="CN7_7" x="-31.55" y="15.4" drill="1"/>
+<pad name="CN7_5" x="-31.55" y="17.94" drill="1"/>
+<pad name="CN7_3" x="-31.55" y="20.48" drill="1"/>
+<pad name="CN7_1" x="-31.55" y="23.02" drill="1"/>
+<pad name="CN7_38" x="-29.01" y="-22.7" drill="1"/>
+<pad name="CN7_34" x="-29.01" y="-17.62" drill="1"/>
+<pad name="CN7_32" x="-29.01" y="-15.08" drill="1"/>
+<pad name="CN7_30" x="-29.01" y="-12.54" drill="1"/>
+<pad name="CN7_28" x="-29.01" y="-10" drill="1"/>
+<pad name="CN7_26" x="-29.01" y="-7.46" drill="1"/>
+<pad name="CN7_24" x="-29.01" y="-4.92" drill="1"/>
+<pad name="CN7_22" x="-29.01" y="-2.38" drill="1"/>
+<pad name="CN7_36" x="-29.01" y="-20.16" drill="1"/>
+<pad name="CN7_20" x="-29.01" y="0.16" drill="1"/>
+<pad name="CN7_18" x="-29.01" y="2.7" drill="1"/>
+<pad name="CN7_16" x="-29.01" y="5.24" drill="1"/>
+<pad name="CN7_14" x="-29.01" y="7.78" drill="1"/>
+<pad name="CN7_12" x="-29.01" y="10.32" drill="1"/>
+<pad name="CN7_10" x="-29.01" y="12.86" drill="1"/>
+<pad name="CN7_8" x="-29.01" y="15.4" drill="1"/>
+<pad name="CN7_6" x="-29.01" y="17.94" drill="1"/>
+<pad name="CN7_4" x="-29.01" y="20.48" drill="1"/>
+<pad name="CN7_2" x="-29.01" y="23.02" drill="1"/>
+<pad name="CN10_36" x="31.95" y="-20.16" drill="1"/>
+<pad name="CN10_34" x="31.95" y="-17.62" drill="1"/>
+<pad name="CN10_32" x="31.95" y="-15.08" drill="1"/>
+<pad name="CN10_30" x="31.95" y="-12.54" drill="1"/>
+<pad name="CN10_28" x="31.95" y="-10" drill="1"/>
+<pad name="CN10_26" x="31.95" y="-7.46" drill="1"/>
+<pad name="CN10_24" x="31.95" y="-4.92" drill="1"/>
+<pad name="CN10_22" x="31.95" y="-2.38" drill="1"/>
+<pad name="CN10_20" x="31.95" y="0.16" drill="1"/>
+<pad name="CN10_18" x="31.95" y="2.7" drill="1"/>
+<pad name="CN10_16" x="31.95" y="5.24" drill="1"/>
+<pad name="CN10_14" x="31.95" y="7.78" drill="1"/>
+<pad name="CN10_12" x="31.95" y="10.32" drill="1"/>
+<pad name="CN10_10" x="31.95" y="12.86" drill="1"/>
+<pad name="CN10_8" x="31.95" y="15.4" drill="1"/>
+<pad name="CN10_6" x="31.95" y="17.94" drill="1"/>
+<pad name="CN10_4" x="31.95" y="20.48" drill="1"/>
+<pad name="CN10_2" x="31.95" y="23.02" drill="1"/>
+<pad name="CN10_37" x="29.41" y="-22.7" drill="1"/>
+<pad name="CN10_35" x="29.41" y="-20.16" drill="1"/>
+<pad name="CN10_33" x="29.41" y="-17.62" drill="1"/>
+<pad name="CN10_31" x="29.41" y="-15.08" drill="1"/>
+<pad name="CN10_29" x="29.41" y="-12.54" drill="1"/>
+<pad name="CN10_27" x="29.41" y="-10" drill="1"/>
+<pad name="CN10_25" x="29.41" y="-7.46" drill="1"/>
+<pad name="CN10_23" x="29.41" y="-4.92" drill="1"/>
+<pad name="CN10_21" x="29.41" y="-2.38" drill="1"/>
+<pad name="CN10_19" x="29.41" y="0.16" drill="1"/>
+<pad name="CN10_17" x="29.41" y="2.7" drill="1"/>
+<pad name="CN10_15" x="29.41" y="5.24" drill="1"/>
+<pad name="CN10_13" x="29.41" y="7.78" drill="1"/>
+<pad name="CN10_11" x="29.41" y="10.32" drill="1"/>
+<pad name="CN10_9" x="29.41" y="12.86" drill="1"/>
+<pad name="CN10_7" x="29.41" y="15.4" drill="1"/>
+<pad name="CN10_5" x="29.41" y="17.94" drill="1"/>
+<pad name="CN10_3" x="29.41" y="20.48" drill="1"/>
+<pad name="CN10_1" x="29.41" y="23.02" drill="1"/>
+<pad name="CN7_39" x="-31.55" y="25.56" drill="1" shape="square"/>
+<pad name="CN7_40" x="-29.01" y="25.56" drill="1"/>
+<pad name="CN10_39" x="31.95" y="25.56" drill="1"/>
+<pad name="CN10_40" x="29.41" y="25.56" drill="1" shape="square"/>
+<wire x1="-32.9" y1="25.5" x2="-33.4" y2="25.5" width="0.127" layer="21"/>
+<wire x1="-33.4" y1="25.5" x2="-33.4" y2="27.2" width="0.127" layer="21"/>
+<wire x1="-33.4" y1="27.2" x2="-31.7" y2="27.2" width="0.127" layer="21"/>
+<wire x1="-27.6" y1="25.5" x2="-27.1" y2="25.5" width="0.127" layer="21"/>
+<wire x1="-27.1" y1="25.5" x2="-27.1" y2="27.2" width="0.127" layer="21"/>
+<wire x1="-27.1" y1="27.2" x2="-29" y2="27.2" width="0.127" layer="21"/>
+<text x="-31.4" y="26.8" size="1.27" layer="21">NC</text>
+<wire x1="28.1" y1="25.5" x2="27.6" y2="25.5" width="0.127" layer="21"/>
+<wire x1="27.6" y1="25.5" x2="27.6" y2="27.2" width="0.127" layer="21"/>
+<wire x1="27.6" y1="27.2" x2="29.3" y2="27.2" width="0.127" layer="21"/>
+<wire x1="33.4" y1="25.5" x2="33.9" y2="25.5" width="0.127" layer="21"/>
+<wire x1="33.9" y1="25.5" x2="33.9" y2="27.2" width="0.127" layer="21"/>
+<wire x1="33.9" y1="27.2" x2="32" y2="27.2" width="0.127" layer="21"/>
+<text x="29.6" y="26.8" size="1.27" layer="21">NC</text>
 </package>
 </packages>
 <symbols>
@@ -1353,6 +1465,7 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 </devices>
 </deviceset>
 <deviceset name="NUCLEO-SHIELD">
+<description>Shield template for ST Nucleo boards</description>
 <gates>
 <gate name="CN7" symbol="NUCLEO_CN7_ALL_PINS" x="-20.32" y="0"/>
 <gate name="CN10" symbol="NUCLEO_CN10_ALL_PINS" x="20.32" y="0"/>
@@ -1442,6 +1555,89 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 </technologies>
 </device>
 <device name="-NORMAL" package="NUCLEO-SHIELD-WITHHOLES-SHORT">
+<connects>
+<connect gate="CN10" pin="11_PA5" pad="CN10_11"/>
+<connect gate="CN10" pin="13_PA6" pad="CN10_13"/>
+<connect gate="CN10" pin="15_PA7" pad="CN10_15"/>
+<connect gate="CN10" pin="17_PB7" pad="CN10_17"/>
+<connect gate="CN10" pin="19_PC7" pad="CN10_19"/>
+<connect gate="CN10" pin="1_PC9" pad="CN10_1"/>
+<connect gate="CN10" pin="21_PA9" pad="CN10_21"/>
+<connect gate="CN10" pin="23_PA8" pad="CN10_23"/>
+<connect gate="CN10" pin="25_PB10" pad="CN10_25"/>
+<connect gate="CN10" pin="27_PB4" pad="CN10_27"/>
+<connect gate="CN10" pin="29_PB5" pad="CN10_29"/>
+<connect gate="CN10" pin="31_PB3" pad="CN10_31"/>
+<connect gate="CN10" pin="33_PA10" pad="CN10_33"/>
+<connect gate="CN10" pin="35_PA2" pad="CN10_35"/>
+<connect gate="CN10" pin="37_PA3" pad="CN10_37"/>
+<connect gate="CN10" pin="3_PB8" pad="CN10_3"/>
+<connect gate="CN10" pin="5_PB9" pad="CN10_5"/>
+<connect gate="CN10" pin="7_AVDD" pad="CN10_7"/>
+<connect gate="CN10" pin="9_GND" pad="CN10_9"/>
+<connect gate="CN10" pin="AGND_32" pad="CN10_32"/>
+<connect gate="CN10" pin="GND_20" pad="CN10_20"/>
+<connect gate="CN10" pin="PA11_14" pad="CN10_14"/>
+<connect gate="CN10" pin="PA12_12" pad="CN10_12"/>
+<connect gate="CN10" pin="PB11_18" pad="CN10_18"/>
+<connect gate="CN10" pin="PB12_16" pad="CN10_16"/>
+<connect gate="CN10" pin="PB13_30" pad="CN10_30"/>
+<connect gate="CN10" pin="PB14_28" pad="CN10_28"/>
+<connect gate="CN10" pin="PB15_26" pad="CN10_26"/>
+<connect gate="CN10" pin="PB1_24" pad="CN10_24"/>
+<connect gate="CN10" pin="PB2_22" pad="CN10_22"/>
+<connect gate="CN10" pin="PC4_34" pad="CN10_34"/>
+<connect gate="CN10" pin="PC5_6" pad="CN10_6"/>
+<connect gate="CN10" pin="PC6_4" pad="CN10_4"/>
+<connect gate="CN10" pin="PC8_2" pad="CN10_2"/>
+<connect gate="CN10" pin="PD8_10" pad="CN10_10"/>
+<connect gate="CN10" pin="PF4_38" pad="CN10_38"/>
+<connect gate="CN10" pin="PF5_36" pad="CN10_36"/>
+<connect gate="CN10" pin="U5V_8" pad="CN10_8"/>
+<connect gate="CN7" pin="11_PF7" pad="CN7_11"/>
+<connect gate="CN7" pin="13_PA13" pad="CN7_13"/>
+<connect gate="CN7" pin="15_PA14" pad="CN7_15"/>
+<connect gate="CN7" pin="17_PA15" pad="CN7_17"/>
+<connect gate="CN7" pin="19_GND" pad="CN7_19"/>
+<connect gate="CN7" pin="1_PC10" pad="CN7_1"/>
+<connect gate="CN7" pin="21_PB7" pad="CN7_21"/>
+<connect gate="CN7" pin="23_PC13" pad="CN7_23"/>
+<connect gate="CN7" pin="25_PC14" pad="CN7_25"/>
+<connect gate="CN7" pin="27_PC15" pad="CN7_27"/>
+<connect gate="CN7" pin="29_PF0" pad="CN7_29"/>
+<connect gate="CN7" pin="31_PF1" pad="CN7_31"/>
+<connect gate="CN7" pin="33_VBAT" pad="CN7_33"/>
+<connect gate="CN7" pin="35_PC2" pad="CN7_35"/>
+<connect gate="CN7" pin="37_PC3" pad="CN7_37"/>
+<connect gate="CN7" pin="3V3_12" pad="CN7_12"/>
+<connect gate="CN7" pin="3V3_16" pad="CN7_16"/>
+<connect gate="CN7" pin="3_PC12" pad="CN7_3"/>
+<connect gate="CN7" pin="5V_18" pad="CN7_18"/>
+<connect gate="CN7" pin="5_VDD" pad="CN7_5"/>
+<connect gate="CN7" pin="7_BOOT0" pad="CN7_7"/>
+<connect gate="CN7" pin="9_PF6" pad="CN7_9"/>
+<connect gate="CN7" pin="E5V_6" pad="CN7_6"/>
+<connect gate="CN7" pin="GND_20" pad="CN7_20"/>
+<connect gate="CN7" pin="GND_22" pad="CN7_22"/>
+<connect gate="CN7" pin="GND_8" pad="CN7_8"/>
+<connect gate="CN7" pin="NC_10" pad="CN7_10"/>
+<connect gate="CN7" pin="NC_26" pad="CN7_26"/>
+<connect gate="CN7" pin="NRST_14" pad="CN7_14"/>
+<connect gate="CN7" pin="PA0_28" pad="CN7_28"/>
+<connect gate="CN7" pin="PA1_30" pad="CN7_30"/>
+<connect gate="CN7" pin="PA4_32" pad="CN7_32"/>
+<connect gate="CN7" pin="PB0_34" pad="CN7_34"/>
+<connect gate="CN7" pin="PC11_2" pad="CN7_2"/>
+<connect gate="CN7" pin="PC1_36" pad="CN7_36"/>
+<connect gate="CN7" pin="PC2_38" pad="CN7_38"/>
+<connect gate="CN7" pin="PD2_4" pad="CN7_4"/>
+<connect gate="CN7" pin="VIN_24" pad="CN7_24"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-20PIN" package="NUCLEO-SHIELD-UNDERSIDE-SHORT-20-PINHEADER">
 <connects>
 <connect gate="CN10" pin="11_PA5" pad="CN10_11"/>
 <connect gate="CN10" pin="13_PA6" pad="CN10_13"/>

--- a/ELL-i-Boards.lbr
+++ b/ELL-i-Boards.lbr
@@ -792,7 +792,7 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="24.3" y1="2.7" x2="24.3" y2="-2.7" width="0.127" layer="21"/>
 <wire x1="24.3" y1="-2.7" x2="-24.3" y2="-2.7" width="0.127" layer="21"/>
 <wire x1="-24.3" y1="-2.7" x2="-24.3" y2="2.7" width="0.127" layer="21"/>
-<text x="0.00" y="-0.00" size="1.5" layer="27" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.5" layer="27" font="vector" ratio="10" align="center">&gt;NAME</text>
 </package>
 <package name="RASPBERRYPI-SHIELD-CONNECTOR">
 <wire x1="-16.165" y1="-0.345" x2="-14.315" y2="-0.345" width="0.127" layer="21"/>
@@ -844,18 +844,16 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <description>&lt;h3&gt;Nucleo shield template with 2*20 pin headers&lt;/h3&gt;
 &lt;p&gt;
 This version of shield has no Arduino headers and it has 2*20 pin headers because they're easier to source than Morpho's 2*19 pin headers.</description>
-<wire x1="-22.8" y1="-26.74" x2="10.2" y2="-26.74" width="0.127" layer="20"/>
-<wire x1="-22.8" y1="-26.74" x2="-23.8" y2="-25.74" width="0.127" layer="20"/>
-<wire x1="-23.8" y1="-25.74" x2="-33.8" y2="-25.74" width="0.127" layer="20"/>
-<wire x1="-34.8" y1="-24.74" x2="-34.8" y2="29.76" width="0.127" layer="20"/>
-<wire x1="-33.8" y1="30.76" x2="34.2" y2="30.76" width="0.127" layer="20"/>
-<wire x1="35.2" y1="-24.74" x2="35.2" y2="29.76" width="0.127" layer="20"/>
-<wire x1="34.2" y1="-25.74" x2="11.2" y2="-25.74" width="0.127" layer="20"/>
-<wire x1="10.2" y1="-26.74" x2="11.2" y2="-25.74" width="0.127" layer="20"/>
-<wire x1="-34.8" y1="29.76" x2="-33.8" y2="30.76" width="0.127" layer="20" curve="-90"/>
-<wire x1="34.2" y1="30.76" x2="35.2" y2="29.76" width="0.127" layer="20" curve="-90"/>
-<wire x1="-33.8" y1="-25.74" x2="-34.8" y2="-24.74" width="0.127" layer="20" curve="-90"/>
-<wire x1="35.2" y1="-24.74" x2="34.2" y2="-25.74" width="0.127" layer="20" curve="-90"/>
+<wire x1="-22.8" y1="-26.74" x2="12.76" y2="-26.74" width="0.127" layer="47"/>
+<wire x1="-22.8" y1="-26.74" x2="-23.8" y2="-25.74" width="0.127" layer="47"/>
+<wire x1="-23.8" y1="-25.74" x2="-33.8" y2="-25.74" width="0.127" layer="47"/>
+<wire x1="-34.8" y1="-24.74" x2="-34.8" y2="29.76" width="0.127" layer="47"/>
+<wire x1="-33.8" y1="30.76" x2="34.2" y2="30.76" width="0.127" layer="47"/>
+<wire x1="35.2" y1="-24.74" x2="35.2" y2="29.76" width="0.127" layer="47"/>
+<wire x1="-34.8" y1="29.76" x2="-33.8" y2="30.76" width="0.127" layer="47" curve="-90"/>
+<wire x1="34.2" y1="30.76" x2="35.2" y2="29.76" width="0.127" layer="47" curve="-90"/>
+<wire x1="-33.8" y1="-25.74" x2="-34.8" y2="-24.74" width="0.127" layer="47" curve="-90"/>
+<wire x1="35.2" y1="-24.74" x2="34.2" y2="-25.74" width="0.127" layer="47" curve="-90"/>
 <pad name="CN7_37" x="-31.55" y="-22.7" drill="1"/>
 <pad name="CN10_38" x="31.95" y="-22.7" drill="1"/>
 <pad name="CN7_33" x="-31.55" y="-17.62" drill="1"/>
@@ -950,6 +948,9 @@ This version of shield has no Arduino headers and it has 2*20 pin headers becaus
 <wire x1="33.9" y1="25.5" x2="33.9" y2="27.2" width="0.127" layer="21"/>
 <wire x1="33.9" y1="27.2" x2="32" y2="27.2" width="0.127" layer="21"/>
 <text x="29.6" y="26.8" size="1.27" layer="21">NC</text>
+<wire x1="12.76" y1="-26.74" x2="13.49" y2="-26.01" width="0.127" layer="47"/>
+<wire x1="34.21" y1="-25.73" x2="13.77" y2="-25.73" width="0.127" layer="47"/>
+<wire x1="13.77" y1="-25.73" x2="13.5" y2="-26" width="0.127" layer="47"/>
 </package>
 </packages>
 <symbols>

--- a/ELL-i-Boards.lbr
+++ b/ELL-i-Boards.lbr
@@ -279,114 +279,114 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="69" y1="82.5" x2="70" y2="81.5" width="0.127" layer="20" curve="-90"/>
 <wire x1="1" y1="1" x2="0" y2="2" width="0.127" layer="20" curve="-90"/>
 <wire x1="70" y1="2" x2="69" y2="1" width="0.127" layer="20" curve="-90"/>
-<pad name="CN7_37" x="3.25" y="4.04" drill="0.8"/>
-<pad name="CN10_38" x="66.75" y="4.04" drill="0.8"/>
-<pad name="CN7_33" x="3.25" y="9.12" drill="0.8"/>
-<pad name="CN7_31" x="3.25" y="11.66" drill="0.8"/>
-<pad name="CN7_29" x="3.25" y="14.2" drill="0.8"/>
-<pad name="CN7_27" x="3.25" y="16.74" drill="0.8"/>
-<pad name="CN7_25" x="3.25" y="19.28" drill="0.8"/>
-<pad name="CN7_23" x="3.25" y="21.82" drill="0.8"/>
-<pad name="CN7_21" x="3.25" y="24.36" drill="0.8"/>
-<pad name="CN7_35" x="3.25" y="6.58" drill="0.8"/>
-<pad name="CN7_19" x="3.25" y="26.9" drill="0.8"/>
-<pad name="CN7_17" x="3.25" y="29.44" drill="0.8"/>
-<pad name="CN7_15" x="3.25" y="31.98" drill="0.8"/>
-<pad name="CN7_13" x="3.25" y="34.52" drill="0.8"/>
-<pad name="CN7_11" x="3.25" y="37.06" drill="0.8"/>
-<pad name="CN7_9" x="3.25" y="39.6" drill="0.8"/>
-<pad name="CN7_7" x="3.25" y="42.14" drill="0.8"/>
-<pad name="CN7_5" x="3.25" y="44.68" drill="0.8"/>
-<pad name="CN7_3" x="3.25" y="47.22" drill="0.8"/>
-<pad name="CN7_1" x="3.25" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN7_38" x="5.79" y="4.04" drill="0.8"/>
-<pad name="CN7_34" x="5.79" y="9.12" drill="0.8"/>
-<pad name="CN7_32" x="5.79" y="11.66" drill="0.8"/>
-<pad name="CN7_30" x="5.79" y="14.2" drill="0.8"/>
-<pad name="CN7_28" x="5.79" y="16.74" drill="0.8"/>
-<pad name="CN7_26" x="5.79" y="19.28" drill="0.8"/>
-<pad name="CN7_24" x="5.79" y="21.82" drill="0.8"/>
-<pad name="CN7_22" x="5.79" y="24.36" drill="0.8"/>
-<pad name="CN7_36" x="5.79" y="6.58" drill="0.8"/>
-<pad name="CN7_20" x="5.79" y="26.9" drill="0.8"/>
-<pad name="CN7_18" x="5.79" y="29.44" drill="0.8"/>
-<pad name="CN7_16" x="5.79" y="31.98" drill="0.8"/>
-<pad name="CN7_14" x="5.79" y="34.52" drill="0.8"/>
-<pad name="CN7_12" x="5.79" y="37.06" drill="0.8"/>
-<pad name="CN7_10" x="5.79" y="39.6" drill="0.8"/>
-<pad name="CN7_8" x="5.79" y="42.14" drill="0.8"/>
-<pad name="CN7_6" x="5.79" y="44.68" drill="0.8"/>
-<pad name="CN7_4" x="5.79" y="47.22" drill="0.8"/>
-<pad name="CN7_2" x="5.79" y="49.76" drill="0.8"/>
-<pad name="CN8_6" x="10.87" y="4.04" drill="0.8"/>
-<pad name="CN8_4" x="10.87" y="9.12" drill="0.8"/>
-<pad name="CN8_3" x="10.87" y="11.66" drill="0.8"/>
-<pad name="CN8_2" x="10.87" y="14.2" drill="0.8"/>
-<pad name="CN8_1" x="10.87" y="16.74" drill="0.8" shape="square"/>
-<pad name="CN6_8" x="10.87" y="21.82" drill="0.8"/>
-<pad name="CN6_7" x="10.87" y="24.36" drill="0.8"/>
-<pad name="CN8_5" x="10.87" y="6.58" drill="0.8"/>
-<pad name="CN6_6" x="10.87" y="26.9" drill="0.8"/>
-<pad name="CN6_5" x="10.87" y="29.44" drill="0.8"/>
-<pad name="CN6_4" x="10.87" y="31.98" drill="0.8"/>
-<pad name="CN6_3" x="10.87" y="34.52" drill="0.8"/>
-<pad name="CN6_2" x="10.87" y="37.06" drill="0.8"/>
-<pad name="CN6_1" x="10.87" y="39.6" drill="0.8" shape="square"/>
-<pad name="CN10_36" x="66.75" y="6.58" drill="0.8"/>
-<pad name="CN10_34" x="66.75" y="9.12" drill="0.8"/>
-<pad name="CN10_32" x="66.75" y="11.66" drill="0.8"/>
-<pad name="CN10_30" x="66.75" y="14.2" drill="0.8"/>
-<pad name="CN10_28" x="66.75" y="16.74" drill="0.8"/>
-<pad name="CN10_26" x="66.75" y="19.28" drill="0.8"/>
-<pad name="CN10_24" x="66.75" y="21.82" drill="0.8"/>
-<pad name="CN10_22" x="66.75" y="24.36" drill="0.8"/>
-<pad name="CN10_20" x="66.75" y="26.9" drill="0.8"/>
-<pad name="CN10_18" x="66.75" y="29.44" drill="0.8"/>
-<pad name="CN10_16" x="66.75" y="31.98" drill="0.8"/>
-<pad name="CN10_14" x="66.75" y="34.52" drill="0.8"/>
-<pad name="CN10_12" x="66.75" y="37.06" drill="0.8"/>
-<pad name="CN10_10" x="66.75" y="39.6" drill="0.8"/>
-<pad name="CN10_8" x="66.75" y="42.14" drill="0.8"/>
-<pad name="CN10_6" x="66.75" y="44.68" drill="0.8"/>
-<pad name="CN10_4" x="66.75" y="47.22" drill="0.8"/>
-<pad name="CN10_2" x="66.75" y="49.76" drill="0.8"/>
-<pad name="CN10_37" x="64.21" y="4.04" drill="0.8"/>
-<pad name="CN10_35" x="64.21" y="6.58" drill="0.8"/>
-<pad name="CN10_33" x="64.21" y="9.12" drill="0.8"/>
-<pad name="CN10_31" x="64.21" y="11.66" drill="0.8"/>
-<pad name="CN10_29" x="64.21" y="14.2" drill="0.8"/>
-<pad name="CN10_27" x="64.21" y="16.74" drill="0.8"/>
-<pad name="CN10_25" x="64.21" y="19.28" drill="0.8"/>
-<pad name="CN10_23" x="64.21" y="21.82" drill="0.8"/>
-<pad name="CN10_21" x="64.21" y="24.36" drill="0.8"/>
-<pad name="CN10_19" x="64.21" y="26.9" drill="0.8"/>
-<pad name="CN10_17" x="64.21" y="29.44" drill="0.8"/>
-<pad name="CN10_15" x="64.21" y="31.98" drill="0.8"/>
-<pad name="CN10_13" x="64.21" y="34.52" drill="0.8"/>
-<pad name="CN10_11" x="64.21" y="37.06" drill="0.8"/>
-<pad name="CN10_9" x="64.21" y="39.6" drill="0.8"/>
-<pad name="CN10_7" x="64.21" y="42.14" drill="0.8"/>
-<pad name="CN10_5" x="64.21" y="44.68" drill="0.8"/>
-<pad name="CN10_3" x="64.21" y="47.22" drill="0.8"/>
-<pad name="CN10_1" x="64.21" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN9_1" x="59.13" y="4.04" drill="0.8" shape="square"/>
-<pad name="CN9_3" x="59.13" y="9.12" drill="0.8"/>
-<pad name="CN9_4" x="59.13" y="11.66" drill="0.8"/>
-<pad name="CN9_5" x="59.13" y="14.2" drill="0.8"/>
-<pad name="CN9_6" x="59.13" y="16.74" drill="0.8"/>
-<pad name="CN9_7" x="59.13" y="19.28" drill="0.8"/>
-<pad name="CN9_8" x="59.13" y="21.82" drill="0.8"/>
-<pad name="CN9_2" x="59.13" y="6.58" drill="0.8"/>
-<pad name="CN5_1" x="59.13" y="25.63" drill="0.8" shape="square"/>
-<pad name="CN5_2" x="59.13" y="28.17" drill="0.8"/>
-<pad name="CN5_3" x="59.13" y="30.71" drill="0.8"/>
-<pad name="CN5_4" x="59.13" y="33.25" drill="0.8"/>
-<pad name="CN5_5" x="59.13" y="35.79" drill="0.8"/>
-<pad name="CN5_6" x="59.13" y="38.33" drill="0.8"/>
-<pad name="CN5_7" x="59.13" y="40.87" drill="0.8"/>
-<pad name="CN5_8" x="59.13" y="43.41" drill="0.8"/>
-<pad name="CN5_9" x="59.13" y="45.95" drill="0.8"/>
-<pad name="CN5_10" x="59.13" y="48.49" drill="0.8"/>
+<pad name="CN7_37" x="3.25" y="4.04" drill="1"/>
+<pad name="CN10_38" x="66.75" y="4.04" drill="1"/>
+<pad name="CN7_33" x="3.25" y="9.12" drill="1"/>
+<pad name="CN7_31" x="3.25" y="11.66" drill="1"/>
+<pad name="CN7_29" x="3.25" y="14.2" drill="1"/>
+<pad name="CN7_27" x="3.25" y="16.74" drill="1"/>
+<pad name="CN7_25" x="3.25" y="19.28" drill="1"/>
+<pad name="CN7_23" x="3.25" y="21.82" drill="1"/>
+<pad name="CN7_21" x="3.25" y="24.36" drill="1"/>
+<pad name="CN7_35" x="3.25" y="6.58" drill="1"/>
+<pad name="CN7_19" x="3.25" y="26.9" drill="1"/>
+<pad name="CN7_17" x="3.25" y="29.44" drill="1"/>
+<pad name="CN7_15" x="3.25" y="31.98" drill="1"/>
+<pad name="CN7_13" x="3.25" y="34.52" drill="1"/>
+<pad name="CN7_11" x="3.25" y="37.06" drill="1"/>
+<pad name="CN7_9" x="3.25" y="39.6" drill="1"/>
+<pad name="CN7_7" x="3.25" y="42.14" drill="1"/>
+<pad name="CN7_5" x="3.25" y="44.68" drill="1"/>
+<pad name="CN7_3" x="3.25" y="47.22" drill="1"/>
+<pad name="CN7_1" x="3.25" y="49.76" drill="1" shape="square"/>
+<pad name="CN7_38" x="5.79" y="4.04" drill="1"/>
+<pad name="CN7_34" x="5.79" y="9.12" drill="1"/>
+<pad name="CN7_32" x="5.79" y="11.66" drill="1"/>
+<pad name="CN7_30" x="5.79" y="14.2" drill="1"/>
+<pad name="CN7_28" x="5.79" y="16.74" drill="1"/>
+<pad name="CN7_26" x="5.79" y="19.28" drill="1"/>
+<pad name="CN7_24" x="5.79" y="21.82" drill="1"/>
+<pad name="CN7_22" x="5.79" y="24.36" drill="1"/>
+<pad name="CN7_36" x="5.79" y="6.58" drill="1"/>
+<pad name="CN7_20" x="5.79" y="26.9" drill="1"/>
+<pad name="CN7_18" x="5.79" y="29.44" drill="1"/>
+<pad name="CN7_16" x="5.79" y="31.98" drill="1"/>
+<pad name="CN7_14" x="5.79" y="34.52" drill="1"/>
+<pad name="CN7_12" x="5.79" y="37.06" drill="1"/>
+<pad name="CN7_10" x="5.79" y="39.6" drill="1"/>
+<pad name="CN7_8" x="5.79" y="42.14" drill="1"/>
+<pad name="CN7_6" x="5.79" y="44.68" drill="1"/>
+<pad name="CN7_4" x="5.79" y="47.22" drill="1"/>
+<pad name="CN7_2" x="5.79" y="49.76" drill="1"/>
+<pad name="CN8_6" x="10.87" y="4.04" drill="1"/>
+<pad name="CN8_4" x="10.87" y="9.12" drill="1"/>
+<pad name="CN8_3" x="10.87" y="11.66" drill="1"/>
+<pad name="CN8_2" x="10.87" y="14.2" drill="1"/>
+<pad name="CN8_1" x="10.87" y="16.74" drill="1" shape="square"/>
+<pad name="CN6_8" x="10.87" y="21.82" drill="1"/>
+<pad name="CN6_7" x="10.87" y="24.36" drill="1"/>
+<pad name="CN8_5" x="10.87" y="6.58" drill="1"/>
+<pad name="CN6_6" x="10.87" y="26.9" drill="1"/>
+<pad name="CN6_5" x="10.87" y="29.44" drill="1"/>
+<pad name="CN6_4" x="10.87" y="31.98" drill="1"/>
+<pad name="CN6_3" x="10.87" y="34.52" drill="1"/>
+<pad name="CN6_2" x="10.87" y="37.06" drill="1"/>
+<pad name="CN6_1" x="10.87" y="39.6" drill="1" shape="square"/>
+<pad name="CN10_36" x="66.75" y="6.58" drill="1"/>
+<pad name="CN10_34" x="66.75" y="9.12" drill="1"/>
+<pad name="CN10_32" x="66.75" y="11.66" drill="1"/>
+<pad name="CN10_30" x="66.75" y="14.2" drill="1"/>
+<pad name="CN10_28" x="66.75" y="16.74" drill="1"/>
+<pad name="CN10_26" x="66.75" y="19.28" drill="1"/>
+<pad name="CN10_24" x="66.75" y="21.82" drill="1"/>
+<pad name="CN10_22" x="66.75" y="24.36" drill="1"/>
+<pad name="CN10_20" x="66.75" y="26.9" drill="1"/>
+<pad name="CN10_18" x="66.75" y="29.44" drill="1"/>
+<pad name="CN10_16" x="66.75" y="31.98" drill="1"/>
+<pad name="CN10_14" x="66.75" y="34.52" drill="1"/>
+<pad name="CN10_12" x="66.75" y="37.06" drill="1"/>
+<pad name="CN10_10" x="66.75" y="39.6" drill="1"/>
+<pad name="CN10_8" x="66.75" y="42.14" drill="1"/>
+<pad name="CN10_6" x="66.75" y="44.68" drill="1"/>
+<pad name="CN10_4" x="66.75" y="47.22" drill="1"/>
+<pad name="CN10_2" x="66.75" y="49.76" drill="1"/>
+<pad name="CN10_37" x="64.21" y="4.04" drill="1"/>
+<pad name="CN10_35" x="64.21" y="6.58" drill="1"/>
+<pad name="CN10_33" x="64.21" y="9.12" drill="1"/>
+<pad name="CN10_31" x="64.21" y="11.66" drill="1"/>
+<pad name="CN10_29" x="64.21" y="14.2" drill="1"/>
+<pad name="CN10_27" x="64.21" y="16.74" drill="1"/>
+<pad name="CN10_25" x="64.21" y="19.28" drill="1"/>
+<pad name="CN10_23" x="64.21" y="21.82" drill="1"/>
+<pad name="CN10_21" x="64.21" y="24.36" drill="1"/>
+<pad name="CN10_19" x="64.21" y="26.9" drill="1"/>
+<pad name="CN10_17" x="64.21" y="29.44" drill="1"/>
+<pad name="CN10_15" x="64.21" y="31.98" drill="1"/>
+<pad name="CN10_13" x="64.21" y="34.52" drill="1"/>
+<pad name="CN10_11" x="64.21" y="37.06" drill="1"/>
+<pad name="CN10_9" x="64.21" y="39.6" drill="1"/>
+<pad name="CN10_7" x="64.21" y="42.14" drill="1"/>
+<pad name="CN10_5" x="64.21" y="44.68" drill="1"/>
+<pad name="CN10_3" x="64.21" y="47.22" drill="1"/>
+<pad name="CN10_1" x="64.21" y="49.76" drill="1" shape="square"/>
+<pad name="CN9_1" x="59.13" y="4.04" drill="1" shape="square"/>
+<pad name="CN9_3" x="59.13" y="9.12" drill="1"/>
+<pad name="CN9_4" x="59.13" y="11.66" drill="1"/>
+<pad name="CN9_5" x="59.13" y="14.2" drill="1"/>
+<pad name="CN9_6" x="59.13" y="16.74" drill="1"/>
+<pad name="CN9_7" x="59.13" y="19.28" drill="1"/>
+<pad name="CN9_8" x="59.13" y="21.82" drill="1"/>
+<pad name="CN9_2" x="59.13" y="6.58" drill="1"/>
+<pad name="CN5_1" x="59.13" y="25.63" drill="1" shape="square"/>
+<pad name="CN5_2" x="59.13" y="28.17" drill="1"/>
+<pad name="CN5_3" x="59.13" y="30.71" drill="1"/>
+<pad name="CN5_4" x="59.13" y="33.25" drill="1"/>
+<pad name="CN5_5" x="59.13" y="35.79" drill="1"/>
+<pad name="CN5_6" x="59.13" y="38.33" drill="1"/>
+<pad name="CN5_7" x="59.13" y="40.87" drill="1"/>
+<pad name="CN5_8" x="59.13" y="43.41" drill="1"/>
+<pad name="CN5_9" x="59.13" y="45.95" drill="1"/>
+<pad name="CN5_10" x="59.13" y="48.49" drill="1"/>
 <wire x1="5.7912" y1="34.5186" x2="10.8712" y2="34.5186" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="37.0586" x2="10.8712" y2="37.0586" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="39.5986" x2="10.8712" y2="39.5986" width="0.127" layer="1"/>
@@ -539,114 +539,114 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="69" y1="57.5" x2="70" y2="56.5" width="0.127" layer="20" curve="-90"/>
 <wire x1="1" y1="1" x2="0" y2="2" width="0.127" layer="20" curve="-90"/>
 <wire x1="70" y1="2" x2="69" y2="1" width="0.127" layer="20" curve="-90"/>
-<pad name="CN7_37" x="3.25" y="4.04" drill="0.8"/>
-<pad name="CN10_38" x="66.75" y="4.04" drill="0.8"/>
-<pad name="CN7_33" x="3.25" y="9.12" drill="0.8"/>
-<pad name="CN7_31" x="3.25" y="11.66" drill="0.8"/>
-<pad name="CN7_29" x="3.25" y="14.2" drill="0.8"/>
-<pad name="CN7_27" x="3.25" y="16.74" drill="0.8"/>
-<pad name="CN7_25" x="3.25" y="19.28" drill="0.8"/>
-<pad name="CN7_23" x="3.25" y="21.82" drill="0.8"/>
-<pad name="CN7_21" x="3.25" y="24.36" drill="0.8"/>
-<pad name="CN7_35" x="3.25" y="6.58" drill="0.8"/>
-<pad name="CN7_19" x="3.25" y="26.9" drill="0.8"/>
-<pad name="CN7_17" x="3.25" y="29.44" drill="0.8"/>
-<pad name="CN7_15" x="3.25" y="31.98" drill="0.8"/>
-<pad name="CN7_13" x="3.25" y="34.52" drill="0.8"/>
-<pad name="CN7_11" x="3.25" y="37.06" drill="0.8"/>
-<pad name="CN7_9" x="3.25" y="39.6" drill="0.8"/>
-<pad name="CN7_7" x="3.25" y="42.14" drill="0.8"/>
-<pad name="CN7_5" x="3.25" y="44.68" drill="0.8"/>
-<pad name="CN7_3" x="3.25" y="47.22" drill="0.8"/>
-<pad name="CN7_1" x="3.25" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN7_38" x="5.79" y="4.04" drill="0.8"/>
-<pad name="CN7_34" x="5.79" y="9.12" drill="0.8"/>
-<pad name="CN7_32" x="5.79" y="11.66" drill="0.8"/>
-<pad name="CN7_30" x="5.79" y="14.2" drill="0.8"/>
-<pad name="CN7_28" x="5.79" y="16.74" drill="0.8"/>
-<pad name="CN7_26" x="5.79" y="19.28" drill="0.8"/>
-<pad name="CN7_24" x="5.79" y="21.82" drill="0.8"/>
-<pad name="CN7_22" x="5.79" y="24.36" drill="0.8"/>
-<pad name="CN7_36" x="5.79" y="6.58" drill="0.8"/>
-<pad name="CN7_20" x="5.79" y="26.9" drill="0.8"/>
-<pad name="CN7_18" x="5.79" y="29.44" drill="0.8"/>
-<pad name="CN7_16" x="5.79" y="31.98" drill="0.8"/>
-<pad name="CN7_14" x="5.79" y="34.52" drill="0.8"/>
-<pad name="CN7_12" x="5.79" y="37.06" drill="0.8"/>
-<pad name="CN7_10" x="5.79" y="39.6" drill="0.8"/>
-<pad name="CN7_8" x="5.79" y="42.14" drill="0.8"/>
-<pad name="CN7_6" x="5.79" y="44.68" drill="0.8"/>
-<pad name="CN7_4" x="5.79" y="47.22" drill="0.8"/>
-<pad name="CN7_2" x="5.79" y="49.76" drill="0.8"/>
-<pad name="CN8_6" x="10.87" y="4.04" drill="0.8"/>
-<pad name="CN8_4" x="10.87" y="9.12" drill="0.8"/>
-<pad name="CN8_3" x="10.87" y="11.66" drill="0.8"/>
-<pad name="CN8_2" x="10.87" y="14.2" drill="0.8"/>
-<pad name="CN8_1" x="10.87" y="16.74" drill="0.8" shape="square"/>
-<pad name="CN6_8" x="10.87" y="21.82" drill="0.8"/>
-<pad name="CN6_7" x="10.87" y="24.36" drill="0.8"/>
-<pad name="CN8_5" x="10.87" y="6.58" drill="0.8"/>
-<pad name="CN6_6" x="10.87" y="26.9" drill="0.8"/>
-<pad name="CN6_5" x="10.87" y="29.44" drill="0.8"/>
-<pad name="CN6_4" x="10.87" y="31.98" drill="0.8"/>
-<pad name="CN6_3" x="10.87" y="34.52" drill="0.8"/>
-<pad name="CN6_2" x="10.87" y="37.06" drill="0.8"/>
-<pad name="CN6_1" x="10.87" y="39.6" drill="0.8" shape="square"/>
-<pad name="CN10_36" x="66.75" y="6.58" drill="0.8"/>
-<pad name="CN10_34" x="66.75" y="9.12" drill="0.8"/>
-<pad name="CN10_32" x="66.75" y="11.66" drill="0.8"/>
-<pad name="CN10_30" x="66.75" y="14.2" drill="0.8"/>
-<pad name="CN10_28" x="66.75" y="16.74" drill="0.8"/>
-<pad name="CN10_26" x="66.75" y="19.28" drill="0.8"/>
-<pad name="CN10_24" x="66.75" y="21.82" drill="0.8"/>
-<pad name="CN10_22" x="66.75" y="24.36" drill="0.8"/>
-<pad name="CN10_20" x="66.75" y="26.9" drill="0.8"/>
-<pad name="CN10_18" x="66.75" y="29.44" drill="0.8"/>
-<pad name="CN10_16" x="66.75" y="31.98" drill="0.8"/>
-<pad name="CN10_14" x="66.75" y="34.52" drill="0.8"/>
-<pad name="CN10_12" x="66.75" y="37.06" drill="0.8"/>
-<pad name="CN10_10" x="66.75" y="39.6" drill="0.8"/>
-<pad name="CN10_8" x="66.75" y="42.14" drill="0.8"/>
-<pad name="CN10_6" x="66.75" y="44.68" drill="0.8"/>
-<pad name="CN10_4" x="66.75" y="47.22" drill="0.8"/>
-<pad name="CN10_2" x="66.75" y="49.76" drill="0.8"/>
-<pad name="CN10_37" x="64.21" y="4.04" drill="0.8"/>
-<pad name="CN10_35" x="64.21" y="6.58" drill="0.8"/>
-<pad name="CN10_33" x="64.21" y="9.12" drill="0.8"/>
-<pad name="CN10_31" x="64.21" y="11.66" drill="0.8"/>
-<pad name="CN10_29" x="64.21" y="14.2" drill="0.8"/>
-<pad name="CN10_27" x="64.21" y="16.74" drill="0.8"/>
-<pad name="CN10_25" x="64.21" y="19.28" drill="0.8"/>
-<pad name="CN10_23" x="64.21" y="21.82" drill="0.8"/>
-<pad name="CN10_21" x="64.21" y="24.36" drill="0.8"/>
-<pad name="CN10_19" x="64.21" y="26.9" drill="0.8"/>
-<pad name="CN10_17" x="64.21" y="29.44" drill="0.8"/>
-<pad name="CN10_15" x="64.21" y="31.98" drill="0.8"/>
-<pad name="CN10_13" x="64.21" y="34.52" drill="0.8"/>
-<pad name="CN10_11" x="64.21" y="37.06" drill="0.8"/>
-<pad name="CN10_9" x="64.21" y="39.6" drill="0.8"/>
-<pad name="CN10_7" x="64.21" y="42.14" drill="0.8"/>
-<pad name="CN10_5" x="64.21" y="44.68" drill="0.8"/>
-<pad name="CN10_3" x="64.21" y="47.22" drill="0.8"/>
-<pad name="CN10_1" x="64.21" y="49.76" drill="0.8" shape="square"/>
-<pad name="CN9_1" x="59.13" y="4.04" drill="0.8" shape="square"/>
-<pad name="CN9_3" x="59.13" y="9.12" drill="0.8"/>
-<pad name="CN9_4" x="59.13" y="11.66" drill="0.8"/>
-<pad name="CN9_5" x="59.13" y="14.2" drill="0.8"/>
-<pad name="CN9_6" x="59.13" y="16.74" drill="0.8"/>
-<pad name="CN9_7" x="59.13" y="19.28" drill="0.8"/>
-<pad name="CN9_8" x="59.13" y="21.82" drill="0.8"/>
-<pad name="CN9_2" x="59.13" y="6.58" drill="0.8"/>
-<pad name="CN5_1" x="59.13" y="25.63" drill="0.8" shape="square"/>
-<pad name="CN5_2" x="59.13" y="28.17" drill="0.8"/>
-<pad name="CN5_3" x="59.13" y="30.71" drill="0.8"/>
-<pad name="CN5_4" x="59.13" y="33.25" drill="0.8"/>
-<pad name="CN5_5" x="59.13" y="35.79" drill="0.8"/>
-<pad name="CN5_6" x="59.13" y="38.33" drill="0.8"/>
-<pad name="CN5_7" x="59.13" y="40.87" drill="0.8"/>
-<pad name="CN5_8" x="59.13" y="43.41" drill="0.8"/>
-<pad name="CN5_9" x="59.13" y="45.95" drill="0.8"/>
-<pad name="CN5_10" x="59.13" y="48.49" drill="0.8"/>
+<pad name="CN7_37" x="3.25" y="4.04" drill="1"/>
+<pad name="CN10_38" x="66.75" y="4.04" drill="1"/>
+<pad name="CN7_33" x="3.25" y="9.12" drill="1"/>
+<pad name="CN7_31" x="3.25" y="11.66" drill="1"/>
+<pad name="CN7_29" x="3.25" y="14.2" drill="1"/>
+<pad name="CN7_27" x="3.25" y="16.74" drill="1"/>
+<pad name="CN7_25" x="3.25" y="19.28" drill="1"/>
+<pad name="CN7_23" x="3.25" y="21.82" drill="1"/>
+<pad name="CN7_21" x="3.25" y="24.36" drill="1"/>
+<pad name="CN7_35" x="3.25" y="6.58" drill="1"/>
+<pad name="CN7_19" x="3.25" y="26.9" drill="1"/>
+<pad name="CN7_17" x="3.25" y="29.44" drill="1"/>
+<pad name="CN7_15" x="3.25" y="31.98" drill="1"/>
+<pad name="CN7_13" x="3.25" y="34.52" drill="1"/>
+<pad name="CN7_11" x="3.25" y="37.06" drill="1"/>
+<pad name="CN7_9" x="3.25" y="39.6" drill="1"/>
+<pad name="CN7_7" x="3.25" y="42.14" drill="1"/>
+<pad name="CN7_5" x="3.25" y="44.68" drill="1"/>
+<pad name="CN7_3" x="3.25" y="47.22" drill="1"/>
+<pad name="CN7_1" x="3.25" y="49.76" drill="1" shape="square"/>
+<pad name="CN7_38" x="5.79" y="4.04" drill="1"/>
+<pad name="CN7_34" x="5.79" y="9.12" drill="1"/>
+<pad name="CN7_32" x="5.79" y="11.66" drill="1"/>
+<pad name="CN7_30" x="5.79" y="14.2" drill="1"/>
+<pad name="CN7_28" x="5.79" y="16.74" drill="1"/>
+<pad name="CN7_26" x="5.79" y="19.28" drill="1"/>
+<pad name="CN7_24" x="5.79" y="21.82" drill="1"/>
+<pad name="CN7_22" x="5.79" y="24.36" drill="1"/>
+<pad name="CN7_36" x="5.79" y="6.58" drill="1"/>
+<pad name="CN7_20" x="5.79" y="26.9" drill="1"/>
+<pad name="CN7_18" x="5.79" y="29.44" drill="1"/>
+<pad name="CN7_16" x="5.79" y="31.98" drill="1"/>
+<pad name="CN7_14" x="5.79" y="34.52" drill="1"/>
+<pad name="CN7_12" x="5.79" y="37.06" drill="1"/>
+<pad name="CN7_10" x="5.79" y="39.6" drill="1"/>
+<pad name="CN7_8" x="5.79" y="42.14" drill="1"/>
+<pad name="CN7_6" x="5.79" y="44.68" drill="1"/>
+<pad name="CN7_4" x="5.79" y="47.22" drill="1"/>
+<pad name="CN7_2" x="5.79" y="49.76" drill="1"/>
+<pad name="CN8_6" x="10.87" y="4.04" drill="1"/>
+<pad name="CN8_4" x="10.87" y="9.12" drill="1"/>
+<pad name="CN8_3" x="10.87" y="11.66" drill="1"/>
+<pad name="CN8_2" x="10.87" y="14.2" drill="1"/>
+<pad name="CN8_1" x="10.87" y="16.74" drill="1" shape="square"/>
+<pad name="CN6_8" x="10.87" y="21.82" drill="1"/>
+<pad name="CN6_7" x="10.87" y="24.36" drill="1"/>
+<pad name="CN8_5" x="10.87" y="6.58" drill="1"/>
+<pad name="CN6_6" x="10.87" y="26.9" drill="1"/>
+<pad name="CN6_5" x="10.87" y="29.44" drill="1"/>
+<pad name="CN6_4" x="10.87" y="31.98" drill="1"/>
+<pad name="CN6_3" x="10.87" y="34.52" drill="1"/>
+<pad name="CN6_2" x="10.87" y="37.06" drill="1"/>
+<pad name="CN6_1" x="10.87" y="39.6" drill="1" shape="square"/>
+<pad name="CN10_36" x="66.75" y="6.58" drill="1"/>
+<pad name="CN10_34" x="66.75" y="9.12" drill="1"/>
+<pad name="CN10_32" x="66.75" y="11.66" drill="1"/>
+<pad name="CN10_30" x="66.75" y="14.2" drill="1"/>
+<pad name="CN10_28" x="66.75" y="16.74" drill="1"/>
+<pad name="CN10_26" x="66.75" y="19.28" drill="1"/>
+<pad name="CN10_24" x="66.75" y="21.82" drill="1"/>
+<pad name="CN10_22" x="66.75" y="24.36" drill="1"/>
+<pad name="CN10_20" x="66.75" y="26.9" drill="1"/>
+<pad name="CN10_18" x="66.75" y="29.44" drill="1"/>
+<pad name="CN10_16" x="66.75" y="31.98" drill="1"/>
+<pad name="CN10_14" x="66.75" y="34.52" drill="1"/>
+<pad name="CN10_12" x="66.75" y="37.06" drill="1"/>
+<pad name="CN10_10" x="66.75" y="39.6" drill="1"/>
+<pad name="CN10_8" x="66.75" y="42.14" drill="1"/>
+<pad name="CN10_6" x="66.75" y="44.68" drill="1"/>
+<pad name="CN10_4" x="66.75" y="47.22" drill="1"/>
+<pad name="CN10_2" x="66.75" y="49.76" drill="1"/>
+<pad name="CN10_37" x="64.21" y="4.04" drill="1"/>
+<pad name="CN10_35" x="64.21" y="6.58" drill="1"/>
+<pad name="CN10_33" x="64.21" y="9.12" drill="1"/>
+<pad name="CN10_31" x="64.21" y="11.66" drill="1"/>
+<pad name="CN10_29" x="64.21" y="14.2" drill="1"/>
+<pad name="CN10_27" x="64.21" y="16.74" drill="1"/>
+<pad name="CN10_25" x="64.21" y="19.28" drill="1"/>
+<pad name="CN10_23" x="64.21" y="21.82" drill="1"/>
+<pad name="CN10_21" x="64.21" y="24.36" drill="1"/>
+<pad name="CN10_19" x="64.21" y="26.9" drill="1"/>
+<pad name="CN10_17" x="64.21" y="29.44" drill="1"/>
+<pad name="CN10_15" x="64.21" y="31.98" drill="1"/>
+<pad name="CN10_13" x="64.21" y="34.52" drill="1"/>
+<pad name="CN10_11" x="64.21" y="37.06" drill="1"/>
+<pad name="CN10_9" x="64.21" y="39.6" drill="1"/>
+<pad name="CN10_7" x="64.21" y="42.14" drill="1"/>
+<pad name="CN10_5" x="64.21" y="44.68" drill="1"/>
+<pad name="CN10_3" x="64.21" y="47.22" drill="1"/>
+<pad name="CN10_1" x="64.21" y="49.76" drill="1" shape="square"/>
+<pad name="CN9_1" x="59.13" y="4.04" drill="1" shape="square"/>
+<pad name="CN9_3" x="59.13" y="9.12" drill="1"/>
+<pad name="CN9_4" x="59.13" y="11.66" drill="1"/>
+<pad name="CN9_5" x="59.13" y="14.2" drill="1"/>
+<pad name="CN9_6" x="59.13" y="16.74" drill="1"/>
+<pad name="CN9_7" x="59.13" y="19.28" drill="1"/>
+<pad name="CN9_8" x="59.13" y="21.82" drill="1"/>
+<pad name="CN9_2" x="59.13" y="6.58" drill="1"/>
+<pad name="CN5_1" x="59.13" y="25.63" drill="1" shape="square"/>
+<pad name="CN5_2" x="59.13" y="28.17" drill="1"/>
+<pad name="CN5_3" x="59.13" y="30.71" drill="1"/>
+<pad name="CN5_4" x="59.13" y="33.25" drill="1"/>
+<pad name="CN5_5" x="59.13" y="35.79" drill="1"/>
+<pad name="CN5_6" x="59.13" y="38.33" drill="1"/>
+<pad name="CN5_7" x="59.13" y="40.87" drill="1"/>
+<pad name="CN5_8" x="59.13" y="43.41" drill="1"/>
+<pad name="CN5_9" x="59.13" y="45.95" drill="1"/>
+<pad name="CN5_10" x="59.13" y="48.49" drill="1"/>
 <wire x1="5.7912" y1="34.5186" x2="10.8712" y2="34.5186" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="37.0586" x2="10.8712" y2="37.0586" width="0.127" layer="1"/>
 <wire x1="5.7912" y1="39.5986" x2="10.8712" y2="39.5986" width="0.127" layer="1"/>
@@ -742,44 +742,56 @@ as defined in the DIN 49073-1:2010-02 standard.&lt;/p&gt;
 <wire x1="56.5" y1="1" x2="55.5" y2="0" width="0.127" layer="49" curve="-90"/>
 </package>
 <package name="NUCLEO-HEADER">
-<pad name="37" x="22.86" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="35" x="20.32" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="33" x="17.78" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="31" x="15.24" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="29" x="12.7" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="27" x="10.16" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="25" x="7.62" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="23" x="5.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="21" x="2.54" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="19" x="0" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="17" x="-2.54" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="15" x="-5.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="13" x="-7.62" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="11" x="-10.16" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="9" x="-12.7" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="7" x="-15.08" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="5" x="-17.78" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="3" x="-20.32" y="-1.27" drill="0.8" rot="R90"/>
-<pad name="1" x="-22.86" y="-1.27" drill="0.8" shape="square" rot="R90"/>
-<pad name="38" x="22.86" y="1.27" drill="0.8" rot="R90"/>
-<pad name="36" x="20.32" y="1.27" drill="0.8" rot="R90"/>
-<pad name="34" x="17.78" y="1.27" drill="0.8" rot="R90"/>
-<pad name="32" x="15.24" y="1.27" drill="0.8" rot="R90"/>
-<pad name="30" x="12.7" y="1.27" drill="0.8" rot="R90"/>
-<pad name="28" x="10.16" y="1.27" drill="0.8" rot="R90"/>
-<pad name="26" x="7.62" y="1.27" drill="0.8" rot="R90"/>
-<pad name="24" x="5.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="22" x="2.54" y="1.27" drill="0.8" rot="R90"/>
-<pad name="20" x="0" y="1.27" drill="0.8" rot="R90"/>
-<pad name="18" x="-2.54" y="1.27" drill="0.8" rot="R90"/>
-<pad name="16" x="-5.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="14" x="-7.62" y="1.27" drill="0.8" rot="R90"/>
-<pad name="12" x="-10.16" y="1.27" drill="0.8" rot="R90"/>
-<pad name="10" x="-12.7" y="1.27" drill="0.8" rot="R90"/>
-<pad name="8" x="-15.08" y="1.27" drill="0.8" rot="R90"/>
-<pad name="6" x="-17.78" y="1.27" drill="0.8" rot="R90"/>
-<pad name="4" x="-20.32" y="1.27" drill="0.8" rot="R90"/>
-<pad name="2" x="-22.86" y="1.27" drill="0.8" rot="R90"/>
+<pad name="37" x="22.86" y="-1.27" drill="1" rot="R90"/>
+<pad name="35" x="20.32" y="-1.27" drill="1" rot="R90"/>
+<pad name="33" x="17.78" y="-1.27" drill="1" rot="R90"/>
+<pad name="31" x="15.24" y="-1.27" drill="1" rot="R90"/>
+<pad name="29" x="12.7" y="-1.27" drill="1" rot="R90"/>
+<pad name="27" x="10.16" y="-1.27" drill="1" rot="R90"/>
+<pad name="25" x="7.62" y="-1.27" drill="1" rot="R90"/>
+<pad name="23" x="5.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="21" x="2.54" y="-1.27" drill="1" rot="R90"/>
+<pad name="19" x="0" y="-1.27" drill="1" rot="R90"/>
+<pad name="17" x="-2.54" y="-1.27" drill="1" rot="R90"/>
+<pad name="15" x="-5.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="13" x="-7.62" y="-1.27" drill="1" rot="R90"/>
+<pad name="11" x="-10.16" y="-1.27" drill="1" rot="R90"/>
+<pad name="9" x="-12.7" y="-1.27" drill="1" rot="R90"/>
+<pad name="7" x="-15.08" y="-1.27" drill="1" rot="R90"/>
+<pad name="5" x="-17.78" y="-1.27" drill="1" rot="R90"/>
+<pad name="3" x="-20.32" y="-1.27" drill="1" rot="R90"/>
+<pad name="1" x="-22.86" y="-1.27" drill="1" shape="square" rot="R90"/>
+<pad name="38" x="22.86" y="1.27" drill="1" rot="R90"/>
+<pad name="36" x="20.32" y="1.27" drill="1" rot="R90"/>
+<pad name="34" x="17.78" y="1.27" drill="1" rot="R90"/>
+<pad name="32" x="15.24" y="1.27" drill="1" rot="R90"/>
+<pad name="30" x="12.7" y="1.27" drill="1" rot="R90"/>
+<pad name="28" x="10.16" y="1.27" drill="1" rot="R90"/>
+<pad name="26" x="7.62" y="1.27" drill="1" rot="R90"/>
+<pad name="24" x="5.08" y="1.27" drill="1" rot="R90"/>
+<pad name="22" x="2.54" y="1.27" drill="1" rot="R90"/>
+<pad name="20" x="0" y="1.27" drill="1" rot="R90"/>
+<pad name="18" x="-2.54" y="1.27" drill="1" rot="R90"/>
+<pad name="16" x="-5.08" y="1.27" drill="1" rot="R90"/>
+<pad name="14" x="-7.62" y="1.27" drill="1" rot="R90"/>
+<pad name="12" x="-10.16" y="1.27" drill="1" rot="R90"/>
+<pad name="10" x="-12.7" y="1.27" drill="1" rot="R90"/>
+<pad name="8" x="-15.08" y="1.27" drill="1" rot="R90"/>
+<pad name="6" x="-17.78" y="1.27" drill="1" rot="R90"/>
+<pad name="4" x="-20.32" y="1.27" drill="1" rot="R90"/>
+<pad name="2" x="-22.86" y="1.27" drill="1" rot="R90"/>
+<text x="-1.27" y="0" size="2" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<rectangle x1="-24.65" y1="-3.05" x2="24.65" y2="3.05" layer="39"/>
+<circle x="-22.86" y="-3.81" radius="0.15" width="0.3" layer="21"/>
+<wire x1="24.13" y1="-2.54" x2="-22.86" y2="-2.54" width="0.127" layer="51"/>
+<wire x1="-22.86" y1="-2.54" x2="-24.13" y2="-1.27" width="0.127" layer="51"/>
+<wire x1="-24.13" y1="-1.27" x2="-24.13" y2="2.54" width="0.127" layer="51"/>
+<wire x1="-24.13" y1="2.54" x2="24.13" y2="2.54" width="0.127" layer="51"/>
+<wire x1="24.13" y1="2.54" x2="24.13" y2="-2.54" width="0.127" layer="51"/>
+<wire x1="-24.3" y1="2.7" x2="24.3" y2="2.7" width="0.127" layer="21"/>
+<wire x1="24.3" y1="2.7" x2="24.3" y2="-2.7" width="0.127" layer="21"/>
+<wire x1="24.3" y1="-2.7" x2="-24.3" y2="-2.7" width="0.127" layer="21"/>
+<wire x1="-24.3" y1="-2.7" x2="-24.3" y2="2.7" width="0.127" layer="21"/>
 </package>
 <package name="RASPBERRYPI-SHIELD-CONNECTOR">
 <wire x1="-16.165" y1="-0.345" x2="-14.315" y2="-0.345" width="0.127" layer="21"/>

--- a/ELL-i-Connectors.lbr
+++ b/ELL-i-Connectors.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.2">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -1492,6 +1492,68 @@
 <wire x1="-2.35" y1="7.9" x2="-2.35" y2="-2.6" width="0.3048" layer="51"/>
 <wire x1="-4.45" y1="12.7" x2="-4.45" y2="10.2" width="0.3048" layer="51"/>
 <wire x1="-3.25" y1="7.9" x2="-3.25" y2="-2.6" width="0.3048" layer="51"/>
+</package>
+<package name="TE1888250-A">
+<description>&lt;h3&gt;Tyco Electronics 1888250 RJ-45 receptacle&lt;/h3&gt;
+
+&lt;p&gt;PCB Mounted RJ45 Jack, Single Port 1x1, Low Profile, 8P8C&lt;/p&gt;
+&lt;p&gt;This connector needs a PCB cutout placed along drawing. Be sure to specify a reasonable radius to inner corners, manufacturer recommendation is 0.5mm. &lt;/p&gt;
+
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt; Part outline is in measures layer.&lt;/li&gt;
+&lt;li&gt; Silkscreen has 0.15 mm width, 0.15 mm clearance from part, 1.5 mm font height. Silkscreen is at tPlace layer.&lt;/li&gt;
+&lt;li&gt; Silkscreen is completely visible after assembly and does not overlap pads.&lt;/li&gt;
+&lt;li&gt;Part name is in tNames layer.&lt;/li&gt;
+&lt;li&gt;Assembly drawing is in tDocu layer.&lt;/li&gt;
+&lt;li&gt;Part has 0.5 mm keepout from dimensions in tKeepout layer.&lt;/li&gt;
+&lt;li&gt;Part does not include cutout.&lt;/li&gt;
+&lt;/ul&gt;
+Please refer to &lt;a href ="http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt;PCB libraries design document&lt;/a&gt; for details. 
+&lt;/p&gt;
+
+&lt;ul&gt;
+   &lt;li&gt;&lt;a href="http://www.te.com/catalog/products/en?q=1888250"&gt;Product web page&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;</description>
+<wire x1="-9" y1="0" x2="-9" y2="13" width="0.127" layer="47"/>
+<wire x1="9" y1="0" x2="9" y2="13" width="0.127" layer="47"/>
+<wire x1="-9" y1="0" x2="9" y2="0" width="0.127" layer="47"/>
+<wire x1="-9" y1="13" x2="9" y2="13" width="0.127" layer="47"/>
+<pad name="1" x="-3.556" y="9.64" drill="0.8"/>
+<pad name="2" x="-2.54" y="7.1" drill="0.8"/>
+<pad name="3" x="-1.524" y="9.64" drill="0.8"/>
+<pad name="5" x="0.508" y="9.64" drill="0.8"/>
+<pad name="7" x="2.54" y="9.64" drill="0.8"/>
+<pad name="4" x="-0.508" y="7.1" drill="0.8"/>
+<pad name="6" x="1.524" y="7.1" drill="0.8"/>
+<pad name="8" x="3.556" y="7.1" drill="0.8"/>
+<pad name="9" x="4.18" y="3.8" drill="0.6"/>
+<pad name="10" x="5.8" y="1.5" drill="0.6"/>
+<pad name="11" x="-5.58" y="3.8" drill="0.6"/>
+<pad name="12" x="-4.14" y="1.5" drill="0.6"/>
+<text x="-4.56" y="8.255" size="0.8128" layer="51">1</text>
+<text x="2.74" y="5.455" size="0.8128" layer="51">8</text>
+<text x="2.64" y="3.455" size="0.8128" layer="51">9</text>
+<text x="3.34" y="1.255" size="0.8128" layer="51">10</text>
+<text x="-4.46" y="3.455" size="0.8128" layer="51">11</text>
+<text x="-2.96" y="1.255" size="0.8128" layer="51">12</text>
+<pad name="GND@1" x="-8.045" y="6.25" drill="1.1"/>
+<pad name="GND@2" x="8.045" y="6.25" drill="1.1"/>
+<pad name="GND@3" x="-6" y="11.85" drill="1.1"/>
+<pad name="GND@4" x="6" y="11.85" drill="1.1"/>
+<wire x1="-9" y1="0" x2="-9" y2="-14" width="0.127" layer="47"/>
+<wire x1="9" y1="0" x2="9" y2="-14" width="0.127" layer="47"/>
+<wire x1="-9.25" y1="-13.5" x2="-9.25" y2="13.25" width="0.15" layer="21"/>
+<wire x1="-9.25" y1="13.25" x2="9.25" y2="13.25" width="0.15" layer="21"/>
+<wire x1="9.25" y1="13.25" x2="9.25" y2="-13.5" width="0.15" layer="21"/>
+<rectangle x1="-9.5" y1="-14.5" x2="9.5" y2="13.5" layer="39"/>
+<wire x1="-9" y1="-14" x2="-9" y2="12.5" width="0.15" layer="51"/>
+<wire x1="-9" y1="12.5" x2="-8.5" y2="13" width="0.15" layer="51"/>
+<wire x1="-8.5" y1="13" x2="9" y2="13" width="0.15" layer="51"/>
+<wire x1="9" y1="13" x2="9" y2="-14" width="0.15" layer="51"/>
+<wire x1="9" y1="-14" x2="-9" y2="-14" width="0.15" layer="51"/>
+<text x="0" y="0" size="1.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
 </package>
 </packages>
 <symbols>
@@ -3264,6 +3326,27 @@ In several package variant, including pogopin version.</description>
 </technologies>
 </device>
 <device name="TE1888250" package="TE1888250">
+<connects>
+<connect gate="LED1" pin="A" pad="10"/>
+<connect gate="LED1" pin="C" pad="9"/>
+<connect gate="LED2" pin="A" pad="11"/>
+<connect gate="LED2" pin="C" pad="12"/>
+<connect gate="RJ45" pin="GND@0" pad="GND@1 GND@3"/>
+<connect gate="RJ45" pin="GND@2" pad="GND@2 GND@4"/>
+<connect gate="RJ45" pin="POE+@4" pad="4"/>
+<connect gate="RJ45" pin="POE+@5" pad="5"/>
+<connect gate="RJ45" pin="POE-@7" pad="7"/>
+<connect gate="RJ45" pin="POE-@8" pad="8"/>
+<connect gate="RJ45" pin="RX+@3" pad="3"/>
+<connect gate="RJ45" pin="RX-@6" pad="6"/>
+<connect gate="RJ45" pin="TX+@1" pad="1"/>
+<connect gate="RJ45" pin="TX-@2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="TE1888250-A" package="TE1888250-A">
 <connects>
 <connect gate="LED1" pin="A" pad="10"/>
 <connect gate="LED1" pin="C" pad="9"/>

--- a/ELL-i-DiscreteSemi.lbr
+++ b/ELL-i-DiscreteSemi.lbr
@@ -464,12 +464,12 @@ Small rectifier package.
 <wire x1="-3.5" y1="-1" x2="-2" y2="-1" width="0.127" layer="47"/>
 <text x="-1.5" y="0" size="1.27" layer="47">~</text>
 <text x="-1.5" y="-2.5" size="1.27" layer="47">~</text>
-<text x="0.5" y="0.5" size="1.27" layer="47">+</text>
-<text x="0.5" y="-2" size="1.27" layer="47">-</text>
+<text x="0.5" y="-2.04" size="1.27" layer="47">+</text>
+<text x="0.5" y="0.54" size="1.27" layer="47">-</text>
 <smd name="AC1" x="-3.1" y="1.25" dx="1" dy="0.8" layer="1"/>
 <smd name="AC2" x="-3.1" y="-1.25" dx="1" dy="0.8" layer="1"/>
-<smd name="+" x="3.1" y="1.25" dx="1" dy="0.8" layer="1"/>
-<smd name="-" x="3.1" y="-1.25" dx="1" dy="0.8" layer="1"/>
+<smd name="-" x="3.1" y="1.25" dx="1" dy="0.8" layer="1"/>
+<smd name="+" x="3.1" y="-1.25" dx="1" dy="0.8" layer="1"/>
 <wire x1="2.5" y1="2.6" x2="-3.5" y2="2.6" width="0.127" layer="21"/>
 <wire x1="2.5" y1="-2.6" x2="-2.6" y2="-2.6" width="0.127" layer="21"/>
 <rectangle x1="-4.1" y1="-2.9" x2="4.1" y2="2.9" layer="39"/>

--- a/ELL-i-DiscreteSemi.lbr
+++ b/ELL-i-DiscreteSemi.lbr
@@ -670,6 +670,16 @@ Footprint with extended pads for handsoldering. &lt;a href="http://www.fairchild
 <technology name=""/>
 </technologies>
 </device>
+<device name="HANDSOLDERING" package="MLP8L33_HS">
+<connects>
+<connect gate="G$1" pin="D" pad="5 6 7 8 F1"/>
+<connect gate="G$1" pin="G" pad="4"/>
+<connect gate="G$1" pin="S" pad="1 2 3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
 </devices>
 </deviceset>
 <deviceset name="DMP21D5UFB4" prefix="T">

--- a/ELL-i-DiscreteSemi.lbr
+++ b/ELL-i-DiscreteSemi.lbr
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.0">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.5" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="0.05" altunitdist="mm" altunit="mm"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -391,19 +391,11 @@ Source: http://www.onsemi.com/pub_link/Collateral/MBRA340T3-D.PDF</description>
 &lt;p&gt;
 Footprint with extended pads for handsoldering. &lt;a href="http://www.fairchildsemi.com/package/packageDetails.html?id=PN_MLOEU-008"&gt;Package web page&lt;/a&gt;
 &lt;/p&gt;</description>
-<wire x1="-1.45" y1="1.65" x2="-1.3" y2="1.65" width="0.1016" layer="21"/>
-<wire x1="-1.3" y1="1.65" x2="1.3" y2="1.65" width="0.1016" layer="51"/>
-<wire x1="1.3" y1="1.65" x2="1.45" y2="1.65" width="0.1016" layer="21"/>
-<wire x1="1.45" y1="1.65" x2="1.45" y2="0.3625" width="0.1016" layer="21"/>
+<wire x1="-1.3" y1="1.65" x2="1.3" y2="1.65" width="0.1016" layer="47"/>
 <wire x1="1.45" y1="0.3625" x2="1.45" y2="-0.375" width="0.1016" layer="51"/>
-<wire x1="1.45" y1="-0.3625" x2="1.45" y2="-1.65" width="0.1016" layer="21"/>
-<wire x1="1.45" y1="-1.65" x2="1.3" y2="-1.65" width="0.1016" layer="21"/>
-<wire x1="1.3" y1="-1.65" x2="-1.3" y2="-1.65" width="0.1016" layer="51"/>
-<wire x1="-1.3" y1="-1.65" x2="-1.45" y2="-1.65" width="0.1016" layer="21"/>
-<wire x1="-1.45" y1="-1.65" x2="-1.45" y2="-0.3625" width="0.1016" layer="21"/>
+<wire x1="1.3" y1="-1.65" x2="-1.1" y2="-1.65" width="0.1016" layer="47"/>
+<wire x1="-1.1" y1="-1.65" x2="-1.3" y2="-1.65" width="0.1016" layer="47"/>
 <wire x1="-1.45" y1="-0.3625" x2="-1.45" y2="0.3625" width="0.1016" layer="51"/>
-<wire x1="-1.45" y1="0.3625" x2="-1.45" y2="1.65" width="0.1016" layer="21"/>
-<circle x="-1.2" y="-1.075" radius="0.125" width="0" layer="21"/>
 <smd name="1" x="-0.975" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
 <smd name="2" x="-0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
 <smd name="3" x="0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
@@ -412,20 +404,142 @@ Footprint with extended pads for handsoldering. &lt;a href="http://www.fairchild
 <smd name="6" x="0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
 <smd name="7" x="-0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
 <smd name="8" x="-0.975" y="1.6" dx="0.42" dy="1.1" layer="1"/>
-<text x="-1.27" y="1.87" size="0.6096" layer="25">&gt;NAME</text>
-<text x="-1.37" y="-2.505" size="0.6096" layer="27">&gt;VALUE</text>
-<rectangle x1="-1.1375" y1="1.275" x2="-0.8125" y2="1.725" layer="51"/>
-<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
-<rectangle x1="0.1625" y1="1.275" x2="0.4875" y2="1.725" layer="51"/>
-<rectangle x1="0.8125" y1="1.275" x2="1.1375" y2="1.725" layer="51"/>
-<rectangle x1="0.8125" y1="-1.725" x2="1.1375" y2="-1.275" layer="51"/>
-<rectangle x1="0.1625" y1="-1.725" x2="0.4875" y2="-1.275" layer="51"/>
-<rectangle x1="-0.4875" y1="-1.725" x2="-0.1625" y2="-1.275" layer="51"/>
-<rectangle x1="-1.1375" y1="-1.725" x2="-0.8125" y2="-1.275" layer="51"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="0.8" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<rectangle x1="-1.1375" y1="1.275" x2="-0.8125" y2="1.725" layer="47"/>
+<rectangle x1="0.8125" y1="1.275" x2="1.1375" y2="1.725" layer="47"/>
+<rectangle x1="0.8125" y1="-1.725" x2="1.1375" y2="-1.275" layer="47"/>
+<rectangle x1="0.1625" y1="-1.725" x2="0.4875" y2="-1.275" layer="47"/>
+<rectangle x1="-0.4875" y1="-1.725" x2="-0.1625" y2="-1.275" layer="47"/>
+<rectangle x1="-1.1375" y1="-1.725" x2="-0.8125" y2="-1.275" layer="47"/>
 <smd name="F1" x="0" y="0.45" dx="2.37" dy="1.7" layer="1"/>
-<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
-<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
-<rectangle x1="0.1325" y1="1.275" x2="0.4575" y2="1.725" layer="51"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="47"/>
+<rectangle x1="0.1325" y1="1.275" x2="0.4575" y2="1.725" layer="47"/>
+<wire x1="1.3" y1="-1.65" x2="1.5" y2="-1.65" width="0.127" layer="47"/>
+<wire x1="1.5" y1="-1.65" x2="1.5" y2="1.65" width="0.127" layer="47"/>
+<wire x1="1.5" y1="1.65" x2="1.3" y2="1.65" width="0.127" layer="47"/>
+<wire x1="-1.3" y1="1.65" x2="-1.5" y2="1.65" width="0.127" layer="47"/>
+<wire x1="-1.5" y1="1.65" x2="-1.5" y2="-1.65" width="0.127" layer="47"/>
+<wire x1="-1.5" y1="-1.65" x2="-1.1" y2="-1.65" width="0.127" layer="47"/>
+<rectangle x1="-2" y1="-2.65" x2="2" y2="2.65" layer="39"/>
+<wire x1="-1.75" y1="1.5" x2="-1.75" y2="-2.15" width="0.15" layer="21"/>
+<wire x1="1.75" y1="1.5" x2="1.75" y2="-1.5" width="0.15" layer="21"/>
+<wire x1="-1.5" y1="2" x2="1.5" y2="2" width="0.15" layer="51"/>
+<wire x1="1.5" y1="2" x2="1.5" y2="-2" width="0.15" layer="51"/>
+<wire x1="1.5" y1="-2" x2="-0.5" y2="-2" width="0.15" layer="51"/>
+<wire x1="-0.5" y1="-2" x2="-1.5" y2="-1" width="0.15" layer="51"/>
+<wire x1="-1.5" y1="-1" x2="-1.5" y2="2" width="0.15" layer="51"/>
+</package>
+<package name="MBS1">
+<description>&lt;h3&gt;MBS-1&lt;/h3&gt;
+&lt;p&gt;
+Small rectifier package. 
+&lt;ul&gt;
+&lt;li&gt;Pads are as manufacturer recommends, 1.0*0.8 mm.&lt;/li&gt;
+&lt;li&gt;Dimensions are drawn in Measures layer.&lt;/li&gt;
+&lt;li&gt;Silkscreen is in tPlace layer, 0.15 mm width.&lt;/li&gt;
+&lt;li&gt;Name is at tDocu and tNames layers.&lt;/li&gt;
+&lt;li&gt;Footprint has 0.5 mm placement courtyard in tKeepout layer.&lt;/li&gt;
+&lt;li&gt;Assembly drawing is in tDocu layer&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;
+&lt;p&gt;
+&lt;a href="http://www.mccsemi.com/up_pdf/MB12S-MB110S%28MBS-1%29.pdf"&gt;drawing&lt;/a&gt;
+&lt;/p&gt;</description>
+<wire x1="1.95" y1="-2.35" x2="-1.95" y2="-2.35" width="0.127" layer="47"/>
+<wire x1="-1.95" y1="-2.35" x2="-1.95" y2="2.35" width="0.127" layer="47"/>
+<wire x1="-1.95" y1="2.35" x2="1.95" y2="2.35" width="0.127" layer="47"/>
+<wire x1="1.95" y1="2.35" x2="1.95" y2="-2.35" width="0.127" layer="47"/>
+<wire x1="2" y1="1.5" x2="3.5" y2="1.5" width="0.127" layer="47"/>
+<wire x1="3.5" y1="1.5" x2="3.5" y2="1" width="0.127" layer="47"/>
+<wire x1="3.5" y1="1" x2="2" y2="1" width="0.127" layer="47"/>
+<wire x1="2" y1="-1.5" x2="3.5" y2="-1.5" width="0.127" layer="47"/>
+<wire x1="3.5" y1="-1.5" x2="3.5" y2="-1" width="0.127" layer="47"/>
+<wire x1="3.5" y1="-1" x2="2" y2="-1" width="0.127" layer="47"/>
+<wire x1="-2" y1="1.5" x2="-3.5" y2="1.5" width="0.127" layer="47"/>
+<wire x1="-3.5" y1="1.5" x2="-3.5" y2="1" width="0.127" layer="47"/>
+<wire x1="-3.5" y1="1" x2="-2" y2="1" width="0.127" layer="47"/>
+<wire x1="-2" y1="-1.5" x2="-3.5" y2="-1.5" width="0.127" layer="47"/>
+<wire x1="-3.5" y1="-1.5" x2="-3.5" y2="-1" width="0.127" layer="47"/>
+<wire x1="-3.5" y1="-1" x2="-2" y2="-1" width="0.127" layer="47"/>
+<text x="-1.5" y="0" size="1.27" layer="47">~</text>
+<text x="-1.5" y="-2.5" size="1.27" layer="47">~</text>
+<text x="0.5" y="0.5" size="1.27" layer="47">+</text>
+<text x="0.5" y="-2" size="1.27" layer="47">-</text>
+<smd name="AC1" x="-3.1" y="1.25" dx="1" dy="0.8" layer="1"/>
+<smd name="AC2" x="-3.1" y="-1.25" dx="1" dy="0.8" layer="1"/>
+<smd name="+" x="3.1" y="1.25" dx="1" dy="0.8" layer="1"/>
+<smd name="-" x="3.1" y="-1.25" dx="1" dy="0.8" layer="1"/>
+<wire x1="2.5" y1="2.6" x2="-3.5" y2="2.6" width="0.127" layer="21"/>
+<wire x1="2.5" y1="-2.6" x2="-2.6" y2="-2.6" width="0.127" layer="21"/>
+<rectangle x1="-4.1" y1="-2.9" x2="4.1" y2="2.9" layer="39"/>
+<wire x1="-4" y1="2.8" x2="4" y2="2.8" width="0.127" layer="51"/>
+<wire x1="4" y1="2.8" x2="4" y2="-2.8" width="0.127" layer="51"/>
+<wire x1="4" y1="-2.8" x2="-4" y2="-2.8" width="0.127" layer="51"/>
+<wire x1="-4" y1="-2.8" x2="-4" y2="2.8" width="0.127" layer="51"/>
+<text x="0" y="0" size="1.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+</package>
+<package name="SOD-123FL-A">
+<description>&lt;h3&gt;IPC-7351 compliant SOD-123-FL footprint, variant A&lt;/h3&gt;
+&lt;p&gt;
+A-variant is suitable for handsoldering and low density boards. Pads are named "A" and "C" to avoid ambiquity.
+&lt;/p&gt;
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;Cathode is to left&lt;/li&gt;
+&lt;li&gt;Center of component lies at origin of grid.&lt;/li&gt;
+&lt;li&gt;Silkscreen is completely visible after assembly&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.55 mm 0.45 mm heels and 0.05 mm sides. Component has 0.5 mm placement courtyard from pads and outline. Silkscreen has 0.15 mm width and 0.15 mm clearance from pads.
+&lt;/p&gt;
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;Silkscreen drawing is at tPlace layer.&lt;/li&gt;
+&lt;li&gt;Silkscreen name is at tNames layer&lt;/li&gt;
+&lt;li&gt;Mechanical outline is at Measures layer.&lt;/li&gt;
+&lt;li&gt;Assembly drawing as at tDocu layer,&lt;/li&gt;
+&lt;li&gt;Placement courtyard is at tKeepout layer&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;
+&lt;p&gt;
+Component dimensios are derived from &lt;a href = "http://www.mccsemi.com/up_pdf/SMD15PL-SMD1200PL%28SOD-123FL%29.pdf"&gt;MCC schottky diode datasheet&lt;/a&gt;. 
+Please refer to &lt;a href="http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt;PCB libraries design document&lt;/a&gt; for details of component footprint drawing.</description>
+<wire x1="-1.5" y1="-0.8" x2="-1.15" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="-1.15" y1="-0.8" x2="1.5" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="1.5" y1="-0.8" x2="1.5" y2="-0.5" width="0.15" layer="47"/>
+<wire x1="1.5" y1="-0.5" x2="1.5" y2="0.5" width="0.15" layer="47"/>
+<wire x1="1.5" y1="0.5" x2="1.5" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.5" y1="0.8" x2="-1.15" y2="0.8" width="0.15" layer="47"/>
+<wire x1="-1.15" y1="0.8" x2="-1.5" y2="0.8" width="0.15" layer="47"/>
+<wire x1="-1.5" y1="0.8" x2="-1.5" y2="0.5" width="0.15" layer="47"/>
+<wire x1="-1.5" y1="0.5" x2="-1.5" y2="-0.5" width="0.15" layer="47"/>
+<wire x1="-1.5" y1="-0.5" x2="-1.5" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="-1.15" y1="-0.8" x2="-1.15" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.5" y1="0.5" x2="1.9" y2="0.5" width="0.15" layer="47"/>
+<wire x1="1.9" y1="0.5" x2="1.9" y2="-0.5" width="0.15" layer="47"/>
+<wire x1="1.9" y1="-0.5" x2="1.5" y2="-0.5" width="0.15" layer="47"/>
+<wire x1="-1.5" y1="-0.5" x2="-1.9" y2="-0.5" width="0.15" layer="47"/>
+<wire x1="-1.9" y1="-0.5" x2="-1.9" y2="0.5" width="0.15" layer="47"/>
+<wire x1="-1.9" y1="0.5" x2="-1.5" y2="0.5" width="0.15" layer="47"/>
+<smd name="C" x="-1.75" y="0" dx="1.4" dy="1.1" layer="1"/>
+<smd name="A" x="1.75" y="0" dx="1.4" dy="1.1" layer="1"/>
+<wire x1="-2.4" y1="0.8" x2="-1.8" y2="0.8" width="0.15" layer="21"/>
+<wire x1="-1.8" y1="0.8" x2="-1.8" y2="1.1" width="0.15" layer="21"/>
+<wire x1="-1.8" y1="1.1" x2="1.5" y2="1.1" width="0.15" layer="21"/>
+<wire x1="1.5" y1="-1.15" x2="-1.8" y2="-1.15" width="0.15" layer="21"/>
+<wire x1="-1.8" y1="-1.15" x2="-1.8" y2="-0.8" width="0.15" layer="21"/>
+<wire x1="-1.8" y1="-0.8" x2="-2.45" y2="-0.8" width="0.15" layer="21"/>
+<rectangle x1="-2.95" y1="-1.3" x2="2.95" y2="1.3" layer="39"/>
+<wire x1="-1.95" y1="-1.2" x2="-2.85" y2="-0.3" width="0.15" layer="51"/>
+<wire x1="-2.85" y1="-0.3" x2="-2.85" y2="1.2" width="0.15" layer="51"/>
+<wire x1="-2.85" y1="1.2" x2="2.85" y2="1.2" width="0.15" layer="51"/>
+<wire x1="2.85" y1="1.2" x2="2.85" y2="-1.2" width="0.15" layer="51"/>
+<wire x1="2.85" y1="-1.2" x2="-1.95" y2="-1.2" width="0.15" layer="51"/>
+<text x="0" y="0" size="1" layer="51" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
 </package>
 </packages>
 <symbols>
@@ -622,6 +736,27 @@ Footprint with extended pads for handsoldering. &lt;a href="http://www.fairchild
 <pin name="A" x="-5.08" y="0" visible="off" length="short" direction="pas"/>
 <wire x1="0" y1="-1.27" x2="-0.762" y2="-1.27" width="0.254" layer="94"/>
 <wire x1="0" y1="1.27" x2="0.762" y2="1.27" width="0.254" layer="94"/>
+</symbol>
+<symbol name="BRIDGE-RECTIFIER">
+<description>&lt;h3&gt;Single phase bridge rectifier&lt;/h3&gt;</description>
+<pin name="AC1" x="-10.16" y="5.08" length="middle" direction="in"/>
+<pin name="AC2" x="-10.16" y="-5.08" length="middle" direction="in"/>
+<pin name="+" x="12.7" y="5.08" length="middle" direction="pwr" rot="R180"/>
+<pin name="-" x="12.7" y="-5.08" length="middle" direction="pwr" rot="R180"/>
+<wire x1="-5.08" y1="-7.62" x2="-5.08" y2="7.62" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="7.62" x2="7.62" y2="7.62" width="0.254" layer="94"/>
+<wire x1="7.62" y1="7.62" x2="7.62" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="7.62" y1="-7.62" x2="-5.08" y2="-7.62" width="0.254" layer="94"/>
+<polygon width="0.254" layer="94">
+<vertex x="2.54" y="-2.54"/>
+<vertex x="2.54" y="2.54"/>
+<vertex x="5.08" y="0"/>
+</polygon>
+<rectangle x1="-2.54" y1="-1.27" x2="2.54" y2="1.27" layer="94"/>
+<text x="-7.62" y="5.08" size="1.778" layer="94">~</text>
+<text x="-7.62" y="-5.08" size="1.778" layer="94">~</text>
+<text x="10.16" y="5.08" size="1.778" layer="94">+</text>
+<text x="10.16" y="-5.08" size="1.778" layer="94">-</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -913,6 +1048,65 @@ General-purpose diode for high-speed switching.
 <connect gate="G$1" pin="D" pad="2 4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="BRIDGE-RECTIFIER">
+<description>&lt;h3&gt;Rectifier bridge, single phase&lt;/h3&gt;</description>
+<gates>
+<gate name="G$1" symbol="BRIDGE-RECTIFIER" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="MBS1">
+<connects>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
+<connect gate="G$1" pin="AC1" pad="AC1"/>
+<connect gate="G$1" pin="AC2" pad="AC2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="SMD1XXPL">
+<description>&lt;h3&gt;Surface mount  schottky diodes, 50-&gt;200 V, 1 A DC&lt;/h3&gt;
+&lt;p&gt;
+This series of schottky diodes has SOD-123-FL package. &lt;a href ="http://www.mccsemi.com/up_pdf/SMD15PL-SMD1200PL%28SOD-123FL%29.pdf"&gt;Datasheet.&lt;/a&gt;
+&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="DIODE-SCHOTTKY" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOD-123FL-A">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MMSZ4XXX" prefix="D" uservalue="yes">
+<description>&lt;h3&gt;500 mV zener diodes, SOD-123, 1.8-&gt;39 V&lt;/h3&gt;
+&lt;p&gt;
+MMSZ4XXX is series of zener diodes, &lt;a href="http://www.mccsemi.com/up_pdf/MMSZ4678-MMSZ4716%28SOD-123%29.pdf"&gt;Datasheet&lt;/a&gt;.
+&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="DIODE-ZENER" x="2.54" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOD-123FL-A">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/ELL-i-DiscreteSemi.lbr
+++ b/ELL-i-DiscreteSemi.lbr
@@ -385,6 +385,47 @@ Source: http://www.onsemi.com/pub_link/Collateral/MBRA340T3-D.PDF</description>
 <rectangle x1="-2.7432" y1="-3.6576" x2="-1.8796" y2="-1.8034" layer="51"/>
 <rectangle x1="1.8796" y1="-3.6576" x2="2.7432" y2="-1.8034" layer="51"/>
 </package>
+<package name="MLP8L33_HS">
+<description>&lt;h3&gt;MLP8L33&lt;/h3&gt;
+&lt;p&gt;
+Footprint with extended pads for handsoldering. &lt;a href="http://www.fairchildsemi.com/package/packageDetails.html?id=PN_MLOEU-008"&gt;Package web page&lt;/a&gt;
+&lt;/p&gt;</description>
+<wire x1="-1.45" y1="1.65" x2="-1.3" y2="1.65" width="0.1016" layer="21"/>
+<wire x1="-1.3" y1="1.65" x2="1.3" y2="1.65" width="0.1016" layer="51"/>
+<wire x1="1.3" y1="1.65" x2="1.45" y2="1.65" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="1.65" x2="1.45" y2="0.3625" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="0.3625" x2="1.45" y2="-0.375" width="0.1016" layer="51"/>
+<wire x1="1.45" y1="-0.3625" x2="1.45" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="1.45" y1="-1.65" x2="1.3" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="1.3" y1="-1.65" x2="-1.3" y2="-1.65" width="0.1016" layer="51"/>
+<wire x1="-1.3" y1="-1.65" x2="-1.45" y2="-1.65" width="0.1016" layer="21"/>
+<wire x1="-1.45" y1="-1.65" x2="-1.45" y2="-0.3625" width="0.1016" layer="21"/>
+<wire x1="-1.45" y1="-0.3625" x2="-1.45" y2="0.3625" width="0.1016" layer="51"/>
+<wire x1="-1.45" y1="0.3625" x2="-1.45" y2="1.65" width="0.1016" layer="21"/>
+<circle x="-1.2" y="-1.075" radius="0.125" width="0" layer="21"/>
+<smd name="1" x="-0.975" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="2" x="-0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="3" x="0.325" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="4" x="0.975" y="-1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="5" x="0.975" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="6" x="0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="7" x="-0.325" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<smd name="8" x="-0.975" y="1.6" dx="0.42" dy="1.1" layer="1"/>
+<text x="-1.27" y="1.87" size="0.6096" layer="25">&gt;NAME</text>
+<text x="-1.37" y="-2.505" size="0.6096" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.1375" y1="1.275" x2="-0.8125" y2="1.725" layer="51"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="0.1625" y1="1.275" x2="0.4875" y2="1.725" layer="51"/>
+<rectangle x1="0.8125" y1="1.275" x2="1.1375" y2="1.725" layer="51"/>
+<rectangle x1="0.8125" y1="-1.725" x2="1.1375" y2="-1.275" layer="51"/>
+<rectangle x1="0.1625" y1="-1.725" x2="0.4875" y2="-1.275" layer="51"/>
+<rectangle x1="-0.4875" y1="-1.725" x2="-0.1625" y2="-1.275" layer="51"/>
+<rectangle x1="-1.1375" y1="-1.725" x2="-0.8125" y2="-1.275" layer="51"/>
+<smd name="F1" x="0" y="0.45" dx="2.37" dy="1.7" layer="1"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="-0.4875" y1="1.275" x2="-0.1625" y2="1.725" layer="51"/>
+<rectangle x1="0.1325" y1="1.275" x2="0.4575" y2="1.725" layer="51"/>
+</package>
 </packages>
 <symbols>
 <symbol name="DIODE-SCHOTTKY">

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -982,7 +982,7 @@ See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-
 <wire x1="0.9" y1="0.6" x2="0.9" y2="-0.6" width="0.127" layer="47"/>
 <wire x1="-0.5" y1="0.85" x2="0.5" y2="0.85" width="0.127" layer="21"/>
 <wire x1="0.5" y1="-0.85" x2="-0.5" y2="-0.85" width="0.127" layer="21"/>
-<rectangle x1="-2" y1="-1.15" x2="2" y2="1.15" layer="41"/>
+<rectangle x1="-2" y1="-1.15" x2="2" y2="1.15" layer="39"/>
 <wire x1="1.9" y1="1" x2="-1.9" y2="1" width="0.127" layer="51"/>
 <wire x1="-1.9" y1="1" x2="-1.9" y2="-1" width="0.127" layer="51"/>
 <wire x1="-1.9" y1="-1" x2="1.9" y2="-1" width="0.127" layer="51"/>
@@ -1024,7 +1024,7 @@ See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-
 <wire x1="-1.3" y1="-0.8" x2="-1.6" y2="-0.8" width="0.15" layer="47"/>
 <wire x1="-1.3" y1="-0.8" x2="-1.3" y2="0.8" width="0.15" layer="47"/>
 <wire x1="1.3" y1="0.8" x2="1.3" y2="-0.8" width="0.15" layer="47"/>
-<rectangle x1="-2.6" y1="-1.35" x2="2.6" y2="1.35" layer="41"/>
+<rectangle x1="-2.6" y1="-1.35" x2="2.6" y2="1.35" layer="39"/>
 <wire x1="-2.5" y1="1.25" x2="2.5" y2="1.25" width="0.15" layer="51"/>
 <wire x1="2.5" y1="1.25" x2="2.5" y2="-1.25" width="0.15" layer="51"/>
 <wire x1="2.5" y1="-1.25" x2="-2.5" y2="-1.25" width="0.15" layer="51"/>

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.0">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -1156,6 +1156,42 @@ This could be a discrete test loop or just a bare copper pad.</description>
 <technology name=""/>
 </technologies>
 </device>
+<device name="0402-B" package="SMD0402-B">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603-A" package="SMD0603-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805-A" package="SMD0805-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="1206-A" package="SMD1206-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
 </devices>
 </deviceset>
 <deviceset name="C" prefix="C" uservalue="yes">
@@ -1210,6 +1246,42 @@ This could be a discrete test loop or just a bare copper pad.</description>
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0402-B" package="SMD0402-B">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603-A" package="SMD0603-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805-A" package="SMD0805-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="1206-A" package="SMD1206-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -787,14 +787,31 @@ Height approx 2.5 mm off board.
 &lt;/p&gt;
 &lt;p&gt;
 Not reviewed.
+&lt;/p&gt;
+
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;Silkscreen has  0.15 mm width, does not overlap pads, is visible after assembly, on tPlace layer&lt;/li&gt;
+&lt;li&gt;Name is on tNames layer, has vector font, 1.5 mm height and 0.15 mm thickness&lt;/li&gt;
+&lt;li&gt;Mechanical outline is on Measures layer&lt;/li&gt;
+&lt;li&gt;Assembly drawing, including name is on tDocu layer&lt;/li&gt;
+&lt;li&gt;Part has extended keepout area for probing&lt;/li&gt;
+&lt;/ul&gt;
 &lt;/p&gt;</description>
 <pad name="P$1" x="0" y="0" drill="1"/>
-<wire x1="1.3" y1="0.4" x2="1.3" y2="-0.4" width="0.127" layer="21"/>
-<wire x1="1.3" y1="0.4" x2="-1.3" y2="0.4" width="0.127" layer="21"/>
-<wire x1="-1.3" y1="0.4" x2="-1.3" y2="-0.4" width="0.127" layer="21"/>
-<wire x1="-1.3" y1="-0.4" x2="1.3" y2="-0.4" width="0.127" layer="21"/>
-<text x="-2.54" y="1.27" size="1.27" layer="21">&gt;NAME</text>
-<text x="-2.54" y="-2.54" size="1.27" layer="21">&gt;VALUE</text>
+<wire x1="1.3" y1="0.4" x2="1.3" y2="-0.4" width="0.127" layer="47"/>
+<wire x1="1.3" y1="0.4" x2="-1.3" y2="0.4" width="0.127" layer="47"/>
+<wire x1="-1.3" y1="0.4" x2="-1.3" y2="-0.4" width="0.127" layer="47"/>
+<wire x1="-1.3" y1="-0.4" x2="1.3" y2="-0.4" width="0.127" layer="47"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="0.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<rectangle x1="-1.5" y1="-1.5" x2="1.5" y2="1.5" layer="39"/>
+<wire x1="0.5" y1="1" x2="-0.5" y2="1" width="0.15" layer="21"/>
+<wire x1="-0.5" y1="-1" x2="0.5" y2="-1" width="0.15" layer="21"/>
+<wire x1="-1" y1="1" x2="1" y2="1" width="0.15" layer="51"/>
+<wire x1="1" y1="1" x2="1" y2="-1" width="0.15" layer="51"/>
+<wire x1="1" y1="-1" x2="-1" y2="-1" width="0.15" layer="51"/>
+<wire x1="-1" y1="-1" x2="-1" y2="1" width="0.15" layer="51"/>
 </package>
 <package name="TP_BARE">
 <description>&lt;h3&gt;Bare copper test point &lt;/h3&gt;

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -866,6 +866,130 @@ Not reviewed.
 <rectangle x1="0.9517" y1="-0.8491" x2="1.7018" y2="0.8509" layer="51"/>
 <rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
 </package>
+<package name="SMD0402-B">
+<description>&lt;h3&gt;IEC 7351 0402 (1005) - nominal&lt;/h3&gt;
+&lt;p&gt;
+Unpolarised SMD 0402 (1005 metric) footprint, variant B. 
+Pads are considered as nominal (tolerances are not accounted) to keep pads at reasonable size. 
+&lt;/p&gt;
+
+&lt;p&gt;
+Center of pads is at &amp;plusmn;0.5 mm, pad size is 0.35 mm toe and heel, 0.05 mm side. Placement courtyard (keepout area) area is 0.25 mm from pads. Silkscreen has 0.12 mm width, refdes has height of 1.2 mm. Silkscreen is intentionally 0.18 mm away from pads instead of recommended 0.12 mm to keep silkscreen clear of soldermask opening.  Refdes is in center of component and must be placed outside component or deleted after layout has been confirmed. Assembly picture outline is drawn at placement courtyard with line width of 0.12 mm.
+&lt;/p&gt;
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;
+Silkscreen is in tPlace layer.
+&lt;/li&gt;
+&lt;li&gt;
+Refdes for silkscreen is in tNames layer.
+&lt;/li&gt;
+&lt;li&gt;
+Assembly picture (incl. refdes) is in tDocu layer
+&lt;/li&gt;
+&lt;li&gt;
+3D outline is in Measure layer.
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;
+
+&lt;p&gt; Please see &lt;a href = "http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt; this document &lt;/a&gt; for details.
+&lt;/p&gt;</description>
+<wire x1="-0.245" y1="0.219" x2="0.245" y2="0.219" width="0.06" layer="47"/>
+<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.06" layer="47"/>
+<smd name="1" x="-0.5" y="0" dx="0.7" dy="0.6" layer="1" roundness="10"/>
+<smd name="2" x="0.5" y="0" dx="0.7" dy="0.6" layer="1" roundness="10"/>
+<rectangle x1="-0.5" y1="-0.25" x2="-0.25" y2="0.25" layer="47"/>
+<rectangle x1="0.25" y1="-0.25" x2="0.5" y2="0.25" layer="47"/>
+<rectangle x1="-1.1" y1="-0.55" x2="1.1" y2="0.55" layer="39"/>
+<text x="0" y="0" size="1.2" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="0.3" y1="0.48" x2="-0.3" y2="0.48" width="0.127" layer="21"/>
+<wire x1="-0.3" y1="-0.48" x2="0.3" y2="-0.48" width="0.127" layer="21"/>
+<wire x1="-1.04" y1="0.49" x2="1.04" y2="0.49" width="0.127" layer="51"/>
+<wire x1="1.04" y1="0.49" x2="1.04" y2="-0.49" width="0.127" layer="51"/>
+<wire x1="1.04" y1="-0.49" x2="-1.04" y2="-0.49" width="0.127" layer="51"/>
+<wire x1="-1.04" y1="-0.49" x2="-1.04" y2="0.49" width="0.127" layer="51"/>
+<text x="0" y="0" size="0.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+</package>
+<package name="SMD0603-A">
+<description>&lt;h3&gt;IPC-7351-C compliant smd 0603 (1608 metric) footprint, variant A&lt;/h3&gt;
+&lt;p&gt;
+Variant A has large pads and placement courtyard, ideal for handsoldering. Footprint might cause tombstoning on reflow soldering process due to large pads compared to component size. This footprint should be selected only for sparsely populated designs and designs where joint needs to be robust.
+&lt;/p&gt;
+&lt;p&gt;
+Origin is in middle of component, pin 1 is at left. Component is not polarized
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.55 mm toes, 0.45 mm heels and 0.05 mm sides. Tolerances of body dimensions are not considered to keep footprint at reasonable size, and width of component pad is considered to be 0. Pad size is 1.0 * 0.9 mm. 
+&lt;/p&gt;
+&lt;p&gt;
+Silkscreen has 0.15 mm clearance from pads and 0.15 mm width. Name is printed on silkscreen on layer tNames, 0.15 mm width and 1.5 mm height. 
+&lt;/p&gt;
+&lt;p&gt;
+Component has placement courtyard of 0.5 mm from pads. 
+tDocument layer is used for assembly drawing.
+Component outline is drawn on measures layer.
+&lt;/p&gt;</description>
+<smd name="P$1" x="-0.8" y="0" dx="1" dy="0.9" layer="1" roundness="10"/>
+<smd name="P$2" x="0.8" y="0" dx="1" dy="0.9" layer="1" roundness="10"/>
+<wire x1="-0.7" y1="-0.2" x2="-0.7" y2="0.2" width="0.4" layer="47"/>
+<wire x1="0.7" y1="0.2" x2="0.7" y2="-0.2" width="0.4" layer="47"/>
+<wire x1="-0.7" y1="0.3" x2="0.7" y2="0.3" width="0.2" layer="47"/>
+<wire x1="0.7" y1="-0.3" x2="-0.7" y2="-0.3" width="0.2" layer="47"/>
+<rectangle x1="-1.8" y1="-0.95" x2="1.8" y2="0.95" layer="39"/>
+<wire x1="-1.7" y1="-0.9" x2="-1.7" y2="0.9" width="0.1" layer="51"/>
+<wire x1="-1.7" y1="0.9" x2="1.7" y2="0.9" width="0.1" layer="51"/>
+<wire x1="1.7" y1="0.9" x2="1.7" y2="-0.9" width="0.1" layer="51"/>
+<wire x1="1.7" y1="-0.9" x2="-1.7" y2="-0.9" width="0.1" layer="51"/>
+<text x="0" y="0" size="0.8" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="0.6" y1="0.65" x2="-0.6" y2="0.65" width="0.15" layer="21"/>
+<wire x1="-0.6" y1="-0.65" x2="0.6" y2="-0.65" width="0.15" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+</package>
+<package name="SMD0805-A">
+<description>&lt;h3&gt;IPC-7351-C compliant smd 0805 (2012 metric) footprint, variant A&lt;/h3&gt;
+&lt;p&gt;
+Variant A has large pads and placement courtyard, ideal for handsoldering. This footprint should be selected only for sparsely populated designs and designs where joint needs to be robust.
+&lt;/p&gt;
+&lt;p&gt;
+Origin is in middle of component, pin 1 is at left. Component is not polarized
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.55 mm toes, 0.45 mm heels and 0.05 mm sides. Tolerances of body dimensions are not considered to keep footprint at reasonable size, and width of component pad is considered to be 0. Pad size is 1.0 * 1.3 mm. 
+&lt;/p&gt;
+&lt;p&gt;
+Silkscreen has 0.15 mm clearance from pads and 0.15 mm width. Name is printed on silkscreen on layer tNames, 0.15 mm width and 1.5 mm height. 
+&lt;/p&gt;
+&lt;p&gt;
+Component has placement courtyard of 0.5 mm from pads. 
+tDocument layer is used for assembly drawing.
+Component outline is drawn on measures layer.
+&lt;/p&gt;
+&lt;p&gt;
+See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-perfection-starts-in-the-cad-library-part-12/"&gt;mentor blog&lt;/a&gt; and &lt;a href ="http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt;PCB libraries presentation&lt;/a&gt; for reference.
+&lt;/p&gt;</description>
+<smd name="P$1" x="-1" y="0" dx="1" dy="1.3" layer="1"/>
+<smd name="P$2" x="1" y="0" dx="1" dy="1.3" layer="1"/>
+<wire x1="-1" y1="-0.6" x2="-1" y2="0.6" width="0.127" layer="47"/>
+<wire x1="-1" y1="0.6" x2="-0.9" y2="0.6" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="0.6" x2="0.9" y2="0.6" width="0.127" layer="47"/>
+<wire x1="0.9" y1="0.6" x2="1" y2="0.6" width="0.127" layer="47"/>
+<wire x1="1" y1="0.6" x2="1" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="1" y1="-0.6" x2="0.9" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="0.9" y1="-0.6" x2="-0.9" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="-0.6" x2="-1" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="-0.6" x2="-0.9" y2="0.6" width="0.127" layer="47"/>
+<wire x1="0.9" y1="0.6" x2="0.9" y2="-0.6" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="0.85" x2="0.5" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.85" x2="-0.5" y2="-0.85" width="0.127" layer="21"/>
+<rectangle x1="-2" y1="-1.15" x2="2" y2="1.15" layer="41"/>
+<wire x1="1.9" y1="1" x2="-1.9" y2="1" width="0.127" layer="51"/>
+<wire x1="-1.9" y1="1" x2="-1.9" y2="-1" width="0.127" layer="51"/>
+<wire x1="-1.9" y1="-1" x2="1.9" y2="-1" width="0.127" layer="51"/>
+<wire x1="1.9" y1="-1" x2="1.9" y2="1" width="0.127" layer="51"/>
+<text x="0" y="0" size="0.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+</package>
 </packages>
 <symbols>
 <symbol name="R_EU">

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -1034,6 +1034,69 @@ See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-
 <wire x1="-1.2" y1="-1.1" x2="1.2" y2="-1.1" width="0.15" layer="21"/>
 <text x="0" y="0" size="1.5" layer="25" ratio="10" align="center">&gt;NAME</text>
 </package>
+<package name="SMD2220-REFLOW">
+<description>&lt;h3&gt;Non-polarized reflow footprint for 2220 (5750 metric) SMD parts&lt;/h3&gt;
+
+&lt;p&gt;
+ Please see &lt;a href="http://product.tdk.com/en/catalog/spec/mlccspec_commercial_general_midvoltage_en.pdf"&gt; TDK MID VOLTAGE CAPACITOR GUIDE&lt;/a&gt; for reference.
+&lt;/p&gt;
+
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;Pads are as per manufacturer recommendations. &lt;/li&gt;
+&lt;li&gt;Mechanical outline is on Measures layer.&lt;/li&gt;
+&lt;li&gt;Silkscreen outline is on tPlace layer, 0.15 mm width. Silkscreen has 0.15 mm clearance from pads.&lt;/li&gt;
+&lt;li&gt;Name is on tPlace layer, 1.5 mm height, 10 % ratio.&lt;/li&gt;
+&lt;li&gt;Assembly drawing is on tDocu layer.&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;</description>
+<wire x1="-2.85" y1="-2.5" x2="2.85" y2="-2.5" width="0.127" layer="47"/>
+<wire x1="2.85" y1="-2.5" x2="2.85" y2="2.5" width="0.127" layer="47"/>
+<wire x1="2.85" y1="2.5" x2="-2.85" y2="2.5" width="0.127" layer="47"/>
+<wire x1="-2.85" y1="2.5" x2="-2.85" y2="-2.5" width="0.127" layer="47"/>
+<smd name="P$1" x="-3.1" y="0" dx="1.4" dy="5" layer="1"/>
+<smd name="P$2" x="3.1" y="0" dx="1.4" dy="5" layer="1"/>
+<wire x1="-2.5" y1="2.7" x2="2.5" y2="2.7" width="0.15" layer="21"/>
+<wire x1="2.5" y1="-2.7" x2="-2.5" y2="-2.7" width="0.15" layer="21"/>
+<text x="0" y="0" size="1.5" layer="27" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.27" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<rectangle x1="-4.2" y1="-3.05" x2="4.2" y2="3" layer="39"/>
+<wire x1="-4.05" y1="2.85" x2="4.05" y2="2.85" width="0.127" layer="51"/>
+<wire x1="4.05" y1="2.85" x2="4.05" y2="-2.9" width="0.127" layer="51"/>
+<wire x1="4.05" y1="-2.9" x2="-4.05" y2="-2.9" width="0.127" layer="51"/>
+<wire x1="-4.05" y1="-2.9" x2="-4.05" y2="2.85" width="0.127" layer="51"/>
+</package>
+<package name="SMD0603-B">
+<description>&lt;h3&gt;IPC-7351-C compliant smd 0603 (1608 metric) footprint, variant B&lt;/h3&gt;
+&lt;p&gt;
+Variant B has nominal pads and placement courtyard. This footprint should be selected only for moderately populated designs. If the design is going to be handsoldered, consider using A-variant.
+&lt;/p&gt;
+&lt;p&gt;
+Origin is in middle of component, pin 1 is at left. Component is not polarized
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.35 mm toes, 0.35 mm heels and 0.03 mm sides. Tolerances of body dimensions are not considered to keep footprint at reasonable size, and width of component pad is considered to be 0. Pad size is 0.7 mm * 0.86 mm. 
+&lt;/p&gt;
+&lt;p&gt;
+Silkscreen has 0.12 mm clearance from pads and 0.12 mm width. Name is printed on silkscreen on layer tNames, 0.12 mm width and 1.2 mm height. 
+&lt;/p&gt;
+&lt;p&gt;
+Component has placement courtyard of 0.25 mm from pads. 
+tDocument layer is used for assembly drawing.
+Component outline is drawn on measures layer.
+&lt;/p&gt;</description>
+<smd name="P$1" x="-0.8" y="0" dx="0.7" dy="0.86" layer="1" roundness="10"/>
+<smd name="P$2" x="0.8" y="0" dx="0.7" dy="0.86" layer="1" roundness="10"/>
+<wire x1="-0.7" y1="-0.2" x2="-0.7" y2="0.2" width="0.4" layer="47"/>
+<wire x1="0.7" y1="0.2" x2="0.7" y2="-0.2" width="0.4" layer="47"/>
+<wire x1="-0.7" y1="0.3" x2="0.7" y2="0.3" width="0.2" layer="47"/>
+<wire x1="0.7" y1="-0.3" x2="-0.7" y2="-0.3" width="0.2" layer="47"/>
+<text x="0" y="0" size="0.8" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.2" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="-0.55" y1="0.59" x2="0.59" y2="0.59" width="0.127" layer="21"/>
+<wire x1="-0.55" y1="-0.59" x2="0.55" y2="-0.59" width="0.127" layer="21"/>
+<rectangle x1="-1.4" y1="-0.68" x2="1.4" y2="0.68" layer="39"/>
+</package>
 </packages>
 <symbols>
 <symbol name="R_EU">
@@ -1192,6 +1255,15 @@ This could be a discrete test loop or just a bare copper pad.</description>
 <technology name=""/>
 </technologies>
 </device>
+<device name="0603-B" package="SMD0603-B">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
 </devices>
 </deviceset>
 <deviceset name="C" prefix="C" uservalue="yes">
@@ -1279,6 +1351,24 @@ This could be a discrete test loop or just a bare copper pad.</description>
 </technologies>
 </device>
 <device name="1206-A" package="SMD1206-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2220-REFLOW" package="SMD2220-REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603-B" package="SMD0603-B">
 <connects>
 <connect gate="G$1" pin="1" pad="P$1"/>
 <connect gate="G$1" pin="2" pad="P$2"/>
@@ -1458,6 +1548,42 @@ This could be a discrete test loop or just a bare copper pad.</description>
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-0402-B" package="SMD0402-B">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-0603-A" package="SMD0603-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-0805-A" package="SMD0805-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-1206-A" package="SMD1206-A">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/ELL-i-Passives.lbr
+++ b/ELL-i-Passives.lbr
@@ -990,6 +990,50 @@ See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-
 <text x="0" y="0" size="0.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
 <text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
 </package>
+<package name="SMD1206-A">
+<description>&lt;h3&gt;IPC-7351-C compliant smd 1206 (3216 metric) footprint, variant A&lt;/h3&gt;
+&lt;p&gt;
+Variant A has large pads and placement courtyard, ideal for handsoldering. This footprint should be selected only for sparsely populated designs and designs where joint needs to be robust.
+&lt;/p&gt;
+&lt;p&gt;
+Origin is in middle of the component, pin 1 is at left. Component is not polarized.
+&lt;/p&gt;
+&lt;p&gt;
+Pads have 0.55 mm toes, 0.45 mm heels and 0.05 mm sides. Tolerances of body dimensions are not considered to keep footprint at reasonable size, and width of component pad is considered to be 0. Pad size is 1.0 * 1.7 mm. 
+&lt;/p&gt;
+&lt;p&gt;
+Silkscreen has 0.15 mm clearance from pads and 0.15 mm width. Name is printed on silkscreen on layer tNames, 0.15 mm width and 1.5 mm height. 
+&lt;/p&gt;
+&lt;p&gt;
+Component has placement courtyard of 0.5 mm from pads. 
+tDocument layer is used for assembly drawing.
+Component outline is drawn on measures layer.
+&lt;/p&gt;
+&lt;p&gt;
+See &lt;a href="http://blogs.mentor.com/tom-hausherr/blog/2011/01/28/pcb-design-perfection-starts-in-the-cad-library-part-12/"&gt;mentor blog&lt;/a&gt; and &lt;a href ="http://www.pcblibraries.com/downloads/Guidelines!PCB_Design_Optimization_Starts_in_the_CAD_Library.asp"&gt;PCB libraries presentation&lt;/a&gt; for reference.
+&lt;/p&gt;</description>
+<smd name="P$1" x="-1.6" y="0" dx="1" dy="1.7" layer="1"/>
+<smd name="P$2" x="1.6" y="0" dx="1" dy="1.7" layer="1"/>
+<wire x1="-1.6" y1="-0.8" x2="-1.6" y2="0.8" width="0.15" layer="47"/>
+<wire x1="-1.6" y1="0.8" x2="-1.3" y2="0.8" width="0.15" layer="47"/>
+<wire x1="-1.3" y1="0.8" x2="1.3" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.3" y1="0.8" x2="1.6" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.6" y1="0.8" x2="1.6" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="1.6" y1="-0.8" x2="1.3" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="1.3" y1="-0.8" x2="-1.3" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="-1.3" y1="-0.8" x2="-1.6" y2="-0.8" width="0.15" layer="47"/>
+<wire x1="-1.3" y1="-0.8" x2="-1.3" y2="0.8" width="0.15" layer="47"/>
+<wire x1="1.3" y1="0.8" x2="1.3" y2="-0.8" width="0.15" layer="47"/>
+<rectangle x1="-2.6" y1="-1.35" x2="2.6" y2="1.35" layer="41"/>
+<wire x1="-2.5" y1="1.25" x2="2.5" y2="1.25" width="0.15" layer="51"/>
+<wire x1="2.5" y1="1.25" x2="2.5" y2="-1.25" width="0.15" layer="51"/>
+<wire x1="2.5" y1="-1.25" x2="-2.5" y2="-1.25" width="0.15" layer="51"/>
+<wire x1="-2.5" y1="-1.25" x2="-2.5" y2="1.25" width="0.15" layer="51"/>
+<text x="0" y="0" size="1" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="1.2" y1="1.1" x2="-1.2" y2="1.1" width="0.15" layer="21"/>
+<wire x1="-1.2" y1="-1.1" x2="1.2" y2="-1.1" width="0.15" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" ratio="10" align="center">&gt;NAME</text>
+</package>
 </packages>
 <symbols>
 <symbol name="R_EU">

--- a/ELL-i-PowerIC.lbr
+++ b/ELL-i-PowerIC.lbr
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.0">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -135,8 +135,8 @@
 <description>&lt;h3&gt;8 leads Small Outline (SO) package with a central powerpad&lt;/h3&gt;
 
 &lt;p&gt;Drawn from the TPS2378 datasheet.&lt;/p&gt;</description>
-<wire x1="2.5" y1="-1.875" x2="2.5" y2="1.775" width="0.127" layer="51"/>
-<wire x1="-2.5" y1="1.775" x2="-2.5" y2="-1.875" width="0.127" layer="51"/>
+<wire x1="2.5" y1="2" x2="2.5" y2="-2" width="0.127" layer="47"/>
+<wire x1="-2.5" y1="2" x2="-2.5" y2="-2" width="0.127" layer="47"/>
 <smd name="1" x="-1.875" y="-2.875" dx="0.45" dy="2.15" layer="1"/>
 <smd name="2" x="-0.625" y="-2.875" dx="0.45" dy="2.15" layer="1"/>
 <smd name="3" x="0.625" y="-2.875" dx="0.45" dy="2.15" layer="1"/>
@@ -145,32 +145,77 @@
 <smd name="6" x="0.625" y="2.875" dx="0.45" dy="2.15" layer="1"/>
 <smd name="7" x="-0.625" y="2.875" dx="0.45" dy="2.15" layer="1"/>
 <smd name="8" x="-1.875" y="2.875" dx="0.45" dy="2.15" layer="1"/>
-<text x="-2.8" y="-1.8" size="0.8128" layer="25" rot="R90">&gt;NAME</text>
-<text x="3.5" y="-2" size="0.8128" layer="27" rot="R90">&gt;VALUE</text>
-<circle x="-1.9" y="-1.3" radius="0.22360625" width="0.127" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="0.8128" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
 <smd name="POWERPAD" x="0" y="0" dx="3.1" dy="2.4" layer="1"/>
-<wire x1="-2.4" y1="1.8" x2="-2.25" y2="1.8" width="0.254" layer="21"/>
-<wire x1="-1.45" y1="1.8" x2="-1.05" y2="1.8" width="0.254" layer="21"/>
-<wire x1="-0.2" y1="1.8" x2="0.2" y2="1.8" width="0.254" layer="21"/>
-<wire x1="1.05" y1="1.8" x2="1.45" y2="1.8" width="0.254" layer="21"/>
-<wire x1="2.4" y1="1.8" x2="2.25" y2="1.8" width="0.254" layer="21"/>
-<wire x1="-2.5" y1="1.7" x2="2.5" y2="1.7" width="0.127" layer="21"/>
-<wire x1="2.5" y1="-1.7" x2="-2.5" y2="-1.7" width="0.127" layer="21"/>
-<wire x1="-2.4" y1="-1.8" x2="-2.25" y2="-1.8" width="0.254" layer="21"/>
-<wire x1="-1.45" y1="-1.8" x2="-1.05" y2="-1.8" width="0.254" layer="21"/>
-<wire x1="-0.2" y1="-1.8" x2="0.2" y2="-1.8" width="0.254" layer="21"/>
-<wire x1="1.05" y1="-1.8" x2="1.45" y2="-1.8" width="0.254" layer="21"/>
-<wire x1="2.4" y1="-1.8" x2="2.25" y2="-1.8" width="0.254" layer="21"/>
+<rectangle x1="-3" y1="-4.5" x2="3" y2="4.5" layer="39"/>
+<wire x1="-2.5" y1="2" x2="-2.05" y2="2" width="0.127" layer="47"/>
+<wire x1="-2.05" y1="2" x2="-1.75" y2="2" width="0.127" layer="47"/>
+<wire x1="-1.75" y1="2" x2="-0.8" y2="2" width="0.127" layer="47"/>
+<wire x1="-0.8" y1="2" x2="-0.5" y2="2" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="2" x2="0.5" y2="2" width="0.127" layer="47"/>
+<wire x1="0.5" y1="2" x2="0.8" y2="2" width="0.127" layer="47"/>
+<wire x1="0.8" y1="2" x2="1.75" y2="2" width="0.127" layer="47"/>
+<wire x1="1.75" y1="2" x2="2.5" y2="2" width="0.127" layer="47"/>
+<wire x1="2.5" y1="-2" x2="2.05" y2="-2" width="0.127" layer="47"/>
+<wire x1="2.05" y1="-2" x2="1.7" y2="-2" width="0.127" layer="47"/>
+<wire x1="1.7" y1="-2" x2="0.8" y2="-2" width="0.127" layer="47"/>
+<wire x1="0.8" y1="-2" x2="0.5" y2="-2" width="0.127" layer="47"/>
+<wire x1="0.5" y1="-2" x2="-0.5" y2="-2" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="-2" x2="-0.8" y2="-2" width="0.127" layer="47"/>
+<wire x1="-0.8" y1="-2" x2="-1.7" y2="-2" width="0.127" layer="47"/>
+<wire x1="-1.7" y1="-2" x2="-2.05" y2="-2" width="0.127" layer="47"/>
+<wire x1="-2.05" y1="-2" x2="-2.5" y2="-2" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="2" x2="-0.5" y2="3.1" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="3.1" x2="-0.8" y2="3.1" width="0.127" layer="47"/>
+<wire x1="-0.8" y1="3.1" x2="-0.8" y2="2" width="0.127" layer="47"/>
+<wire x1="-2.05" y1="2" x2="-2.05" y2="3.1" width="0.127" layer="47"/>
+<wire x1="-2.05" y1="3.1" x2="-1.75" y2="3.1" width="0.127" layer="47"/>
+<wire x1="-1.75" y1="3.1" x2="-1.75" y2="2" width="0.127" layer="47"/>
+<wire x1="0.5" y1="2" x2="0.5" y2="3.1" width="0.127" layer="47"/>
+<wire x1="0.5" y1="3.1" x2="0.8" y2="3.1" width="0.127" layer="47"/>
+<wire x1="0.8" y1="3.1" x2="0.8" y2="2" width="0.127" layer="47"/>
+<wire x1="2" y1="2.05" x2="2" y2="3.1" width="0.127" layer="47"/>
+<wire x1="2" y1="3.1" x2="1.75" y2="3.1" width="0.127" layer="47"/>
+<wire x1="1.75" y1="3.1" x2="1.75" y2="2" width="0.127" layer="47"/>
+<wire x1="-2.05" y1="-2" x2="-2.05" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="-2.05" y1="-3.1" x2="-1.7" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="-1.7" y1="-3.1" x2="-1.7" y2="-2" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="-2" x2="-0.5" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="-0.5" y1="-3.1" x2="-0.8" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="-0.8" y1="-3.1" x2="-0.8" y2="-2" width="0.127" layer="47"/>
+<wire x1="0.5" y1="-2" x2="0.5" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="0.5" y1="-3.1" x2="0.8" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="0.8" y1="-3.1" x2="0.8" y2="-2" width="0.127" layer="47"/>
+<wire x1="2.05" y1="-2" x2="2.05" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="2.05" y1="-3.1" x2="1.7" y2="-3.1" width="0.127" layer="47"/>
+<wire x1="1.7" y1="-3.1" x2="1.7" y2="-2" width="0.127" layer="47"/>
+<wire x1="-2.75" y1="2" x2="-2.75" y2="-3.9" width="0.15" layer="21"/>
+<wire x1="2.75" y1="2" x2="2.75" y2="-2" width="0.15" layer="21"/>
+<wire x1="2.65" y1="4.1" x2="-2.75" y2="4.1" width="0.15" layer="51"/>
+<wire x1="-2.75" y1="4.1" x2="-2.75" y2="-3.05" width="0.15" layer="51"/>
+<wire x1="-2.75" y1="-3.05" x2="-1.8" y2="-4" width="0.15" layer="51"/>
+<wire x1="-1.8" y1="-4" x2="2.65" y2="-4" width="0.15" layer="51"/>
+<wire x1="2.65" y1="-4" x2="2.65" y2="4.1" width="0.15" layer="51"/>
 </package>
 <package name="MSOP16(12)">
 <description>&lt;h3&gt;16 leads Miniature Small Outline Package (MSOP) plastic with 4 pins removed&lt;/h3&gt;
 
-&lt;p&gt;Drawn from the LT3748 datasheet.&lt;/p&gt;</description>
-<wire x1="2.02" y1="1.5" x2="2.02" y2="-1.5" width="0.2032" layer="21"/>
-<wire x1="-2.02" y1="-1.5" x2="-2.02" y2="1.5" width="0.2032" layer="21"/>
-<wire x1="-2.02" y1="-1.5" x2="2.02" y2="-1.5" width="0.2032" layer="21"/>
-<wire x1="-2.02" y1="1.5" x2="2.02" y2="1.5" width="0.2032" layer="21"/>
-<circle x="-1.4456" y="-0.8406" radius="0.2727" width="0.0508" layer="21"/>
+&lt;p&gt;Drawn from the LT3748 datasheet.&lt;/p&gt;
+
+&lt;p&gt;
+&lt;ul&gt;
+&lt;li&gt;Pads are as per manufacturer recommendations. &lt;/li&gt;
+&lt;li&gt;Mechanical outline is on Measures layer.&lt;/li&gt;
+&lt;li&gt;Silkscreen outline is on tPlace layer, 0.15 mm width. Silkscreen has 0.15 mm clearance from pads and body.&lt;/li&gt;
+&lt;li&gt;Name is on tNames layer, 1.5 mm height, 10 % ratio.&lt;/li&gt;
+&lt;li&gt;Assembly drawing is on tDocu layer.&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/p&gt;</description>
+<wire x1="2.02" y1="1.5" x2="2.02" y2="-1.5" width="0.2032" layer="47"/>
+<wire x1="-2.02" y1="-1.5" x2="-2.02" y2="1.5" width="0.2032" layer="47"/>
+<wire x1="-2.02" y1="-1.5" x2="2.02" y2="-1.5" width="0.2032" layer="47"/>
+<wire x1="-2.02" y1="1.5" x2="2.02" y2="1.5" width="0.2032" layer="47"/>
 <smd name="1" x="-1.75" y="-2.4" dx="0.3" dy="1.02" layer="1"/>
 <smd name="3" x="-0.75" y="-2.4" dx="0.3" dy="1.02" layer="1"/>
 <smd name="5" x="0.25" y="-2.4" dx="0.3" dy="1.02" layer="1"/>
@@ -181,35 +226,43 @@
 <smd name="9" x="1.75" y="2.4" dx="0.3" dy="1.02" layer="1" rot="R180"/>
 <smd name="14" x="-0.75" y="2.4" dx="0.3" dy="1.02" layer="1" rot="R180"/>
 <smd name="16" x="-1.75" y="2.4" dx="0.3" dy="1.02" layer="1" rot="R180"/>
-<text x="-2.532" y="-2.54" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
-<text x="3.802" y="-2.54" size="1.27" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-1.875" y1="-2.45" x2="-1.625" y2="-1.825" layer="51"/>
-<rectangle x1="-1.875" y1="-1.825" x2="-1.625" y2="-1.475" layer="21"/>
-<rectangle x1="-0.875" y1="-2.45" x2="-0.625" y2="-1.825" layer="51"/>
-<rectangle x1="-0.875" y1="-1.825" x2="-0.625" y2="-1.475" layer="21"/>
-<rectangle x1="0.125" y1="-2.45" x2="0.375" y2="-1.825" layer="51"/>
-<rectangle x1="0.125" y1="-1.825" x2="0.375" y2="-1.475" layer="21"/>
-<rectangle x1="0.625" y1="-2.45" x2="0.875" y2="-1.825" layer="51"/>
-<rectangle x1="0.625" y1="-1.825" x2="0.875" y2="-1.475" layer="21"/>
-<rectangle x1="1.125" y1="-2.45" x2="1.375" y2="-1.825" layer="51"/>
-<rectangle x1="1.125" y1="-1.825" x2="1.375" y2="-1.475" layer="21"/>
-<rectangle x1="1.125" y1="1.825" x2="1.375" y2="2.45" layer="51" rot="R180"/>
-<rectangle x1="1.125" y1="1.475" x2="1.375" y2="1.825" layer="21" rot="R180"/>
-<rectangle x1="0.625" y1="1.825" x2="0.875" y2="2.45" layer="51" rot="R180"/>
-<rectangle x1="0.625" y1="1.475" x2="0.875" y2="1.825" layer="21" rot="R180"/>
-<rectangle x1="-0.875" y1="1.825" x2="-0.625" y2="2.45" layer="51" rot="R180"/>
-<rectangle x1="0.125" y1="1.475" x2="0.375" y2="1.825" layer="21" rot="R180"/>
-<rectangle x1="1.625" y1="1.825" x2="1.875" y2="2.45" layer="51" rot="R180"/>
-<rectangle x1="-0.875" y1="1.475" x2="-0.625" y2="1.825" layer="21" rot="R180"/>
-<rectangle x1="-1.875" y1="1.825" x2="-1.625" y2="2.45" layer="51" rot="R180"/>
-<rectangle x1="-1.875" y1="1.475" x2="-1.625" y2="1.825" layer="21" rot="R180"/>
-<rectangle x1="0.125" y1="1.825" x2="0.375" y2="2.45" layer="51" rot="R180"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="0.8" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<rectangle x1="-1.875" y1="-2.45" x2="-1.625" y2="-1.825" layer="47"/>
+<rectangle x1="-1.875" y1="-1.825" x2="-1.625" y2="-1.475" layer="47"/>
+<rectangle x1="-0.875" y1="-2.45" x2="-0.625" y2="-1.825" layer="47"/>
+<rectangle x1="-0.875" y1="-1.825" x2="-0.625" y2="-1.475" layer="47"/>
+<rectangle x1="0.125" y1="-2.45" x2="0.375" y2="-1.825" layer="47"/>
+<rectangle x1="0.125" y1="-1.825" x2="0.375" y2="-1.475" layer="47"/>
+<rectangle x1="0.625" y1="-2.45" x2="0.875" y2="-1.825" layer="47"/>
+<rectangle x1="0.625" y1="-1.825" x2="0.875" y2="-1.475" layer="47"/>
+<rectangle x1="1.125" y1="-2.45" x2="1.375" y2="-1.825" layer="47"/>
+<rectangle x1="1.125" y1="-1.825" x2="1.375" y2="-1.475" layer="47"/>
+<rectangle x1="1.125" y1="1.825" x2="1.375" y2="2.45" layer="47" rot="R180"/>
+<rectangle x1="1.125" y1="1.475" x2="1.375" y2="1.825" layer="47" rot="R180"/>
+<rectangle x1="0.625" y1="1.825" x2="0.875" y2="2.45" layer="47" rot="R180"/>
+<rectangle x1="0.625" y1="1.475" x2="0.875" y2="1.825" layer="47" rot="R180"/>
+<rectangle x1="-0.875" y1="1.825" x2="-0.625" y2="2.45" layer="47" rot="R180"/>
+<rectangle x1="0.125" y1="1.475" x2="0.375" y2="1.825" layer="47" rot="R180"/>
+<rectangle x1="1.625" y1="1.825" x2="1.875" y2="2.45" layer="47" rot="R180"/>
+<rectangle x1="-0.875" y1="1.475" x2="-0.625" y2="1.825" layer="47" rot="R180"/>
+<rectangle x1="-1.875" y1="1.825" x2="-1.625" y2="2.45" layer="47" rot="R180"/>
+<rectangle x1="-1.875" y1="1.475" x2="-1.625" y2="1.825" layer="47" rot="R180"/>
+<rectangle x1="0.125" y1="1.825" x2="0.375" y2="2.45" layer="47" rot="R180"/>
 <smd name="12" x="0.25" y="2.4" dx="0.3" dy="1.02" layer="1" rot="R180"/>
-<rectangle x1="1.625" y1="1.475" x2="1.875" y2="1.825" layer="21" rot="R180"/>
-<rectangle x1="1.625" y1="-1.825" x2="1.875" y2="-1.475" layer="21"/>
-<rectangle x1="1.125" y1="-2.45" x2="1.375" y2="-1.825" layer="51"/>
-<rectangle x1="1.625" y1="-2.45" x2="1.875" y2="-1.825" layer="51"/>
+<rectangle x1="1.625" y1="1.475" x2="1.875" y2="1.825" layer="47" rot="R180"/>
+<rectangle x1="1.625" y1="-1.825" x2="1.875" y2="-1.475" layer="47"/>
+<rectangle x1="1.125" y1="-2.45" x2="1.375" y2="-1.825" layer="47"/>
+<rectangle x1="1.625" y1="-2.45" x2="1.875" y2="-1.825" layer="47"/>
 <smd name="8" x="1.75" y="-2.4" dx="0.3" dy="1.02" layer="1"/>
+<wire x1="-2.25" y1="1.5" x2="-2.25" y2="-2.85" width="0.15" layer="21"/>
+<wire x1="2.25" y1="1.5" x2="2.25" y2="-1.5" width="0.15" layer="21"/>
+<rectangle x1="-2.5" y1="-3.4" x2="2.5" y2="3.4" layer="39"/>
+<wire x1="-2" y1="2.5" x2="2" y2="2.5" width="0.15" layer="51"/>
+<wire x1="2" y1="2.5" x2="2" y2="-2.5" width="0.15" layer="51"/>
+<wire x1="2" y1="-2.5" x2="-1" y2="-2.5" width="0.15" layer="51"/>
+<wire x1="-1" y1="-2.5" x2="-2" y2="-1.5" width="0.15" layer="51"/>
+<wire x1="-2" y1="-1.5" x2="-2" y2="2.5" width="0.15" layer="51"/>
 </package>
 <package name="UQFN6">
 <description>&lt;h3&gt;6 leads Micro Quad Flat None (uFQN) package&lt;/h3&gt;

--- a/ELL-i-Transformers.lbr
+++ b/ELL-i-Transformers.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.0">
+<eagle version="7.1.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -282,6 +282,101 @@
 <wire x1="-5" y1="5.5" x2="5" y2="5.5" width="2" layer="46"/>
 <wire x1="-5" y1="-5.5" x2="5" y2="-5.5" width="2" layer="46"/>
 </package>
+<package name="WE_749119350">
+<description>&lt;h3&gt;Wurth 749119350 footprint, IPC-7351 compliant&lt;/h3&gt;
+&lt;p&gt;
+Pads are as manufacturer recommends. Footprint has 1 mm placement courtyard because of it's height, to ease hand soldering of neighbouring components.
+&lt;/p&gt;
+&lt;p&gt;
+ &lt;ul&gt;
+  &lt;li&gt;
+  Silkscreen is on tPlace layer and has 0.15 mm width. 
+  &lt;/li&gt;
+  &lt;li&gt;
+  Assembly picture is on tDocu layer.
+  &lt;/li&gt;
+  &lt;li&gt;
+  Reference is on tNames and tDocu layers.
+  &lt;/li&gt;
+&lt;/p&gt;
+&lt;p&gt;
+Primary inductance is 120 uH, isolation voltage is 1,5 kV AC between primary and secondary.  
+&lt;/p&gt;
+&lt;p&gt;
+&lt;a href="http://docs-europe.electrocomponents.com/webdocs/079f/0900766b8079f831.pdf"&gt;Datasheet&lt;/a&gt;
+&lt;/p&gt;</description>
+<smd name="P$1" x="-6.35" y="-10.15" dx="1.75" dy="3.45" layer="1"/>
+<smd name="P$2" x="-3.81" y="-10.15" dx="1.75" dy="3.45" layer="1"/>
+<smd name="P$3" x="-1.27" y="-10.15" dx="1.75" dy="3.45" layer="1"/>
+<smd name="P$4" x="1.27" y="-10.15" dx="1.75" dy="3.45" layer="1"/>
+<smd name="P$5" x="3.81" y="-10.15" dx="1.75" dy="3.45" layer="1"/>
+<smd name="P$6" x="6.35" y="-10.15" dx="1.75" dy="3.45" layer="1"/>
+<smd name="P$7" x="6.35" y="10.15" dx="1.75" dy="3.45" layer="1" rot="R180"/>
+<smd name="P$8" x="3.81" y="10.15" dx="1.75" dy="3.45" layer="1" rot="R180"/>
+<smd name="P$9" x="1.27" y="10.15" dx="1.75" dy="3.45" layer="1" rot="R180"/>
+<smd name="P$10" x="-1.27" y="10.15" dx="1.75" dy="3.45" layer="1" rot="R180"/>
+<smd name="P$11" x="-3.81" y="10.15" dx="1.75" dy="3.45" layer="1" rot="R180"/>
+<smd name="P$12" x="-6.35" y="10.15" dx="1.75" dy="3.45" layer="1" rot="R180"/>
+<wire x1="8" y1="-7.75" x2="6.75" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="6.75" y1="-7.75" x2="5.95" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="5.95" y1="-7.75" x2="4.2" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="4.2" y1="-7.75" x2="3.45" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="3.45" y1="-7.75" x2="1.65" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="1.65" y1="-7.75" x2="0.85" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="0.85" y1="-7.75" x2="-0.85" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-0.85" y1="-7.75" x2="-1.65" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-1.65" y1="-7.75" x2="-3.45" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-3.45" y1="-7.75" x2="-4.25" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-4.25" y1="-7.75" x2="-6" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-6" y1="-7.75" x2="-6.75" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-6.75" y1="-7.75" x2="-8" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-8" y1="-7.75" x2="-8" y2="7.75" width="0.127" layer="47"/>
+<wire x1="-8" y1="7.75" x2="8" y2="7.75" width="0.127" layer="47"/>
+<wire x1="8" y1="7.75" x2="8" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-6.75" y1="-7.75" x2="-6.75" y2="-11" width="0.127" layer="47"/>
+<wire x1="-6.75" y1="-11" x2="-6" y2="-11" width="0.127" layer="47"/>
+<wire x1="-6" y1="-11" x2="-6" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-4.25" y1="-7.75" x2="-4.25" y2="-11" width="0.127" layer="47"/>
+<wire x1="-4.25" y1="-11" x2="-3.45" y2="-11" width="0.127" layer="47"/>
+<wire x1="-3.45" y1="-11" x2="-3.45" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="-1.65" y1="-7.75" x2="-1.65" y2="-11" width="0.127" layer="47"/>
+<wire x1="-1.65" y1="-11" x2="-0.85" y2="-11" width="0.127" layer="47"/>
+<wire x1="-0.85" y1="-11" x2="-0.85" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="0.85" y1="-7.75" x2="0.85" y2="-11" width="0.127" layer="47"/>
+<wire x1="0.85" y1="-11" x2="1.65" y2="-11" width="0.127" layer="47"/>
+<wire x1="1.65" y1="-11" x2="1.65" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="3.45" y1="-7.75" x2="3.45" y2="-11" width="0.127" layer="47"/>
+<wire x1="3.45" y1="-11" x2="4.2" y2="-11" width="0.127" layer="47"/>
+<wire x1="4.2" y1="-11" x2="4.2" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="5.95" y1="-7.75" x2="5.95" y2="-11" width="0.127" layer="47"/>
+<wire x1="5.95" y1="-11" x2="6.75" y2="-11" width="0.127" layer="47"/>
+<wire x1="6.75" y1="-11" x2="6.75" y2="-7.75" width="0.127" layer="47"/>
+<wire x1="6.7" y1="7.75" x2="6.7" y2="11" width="0.127" layer="47"/>
+<wire x1="6.7" y1="11" x2="5.95" y2="11" width="0.127" layer="47"/>
+<wire x1="5.95" y1="11" x2="5.95" y2="7.75" width="0.127" layer="47"/>
+<wire x1="4.2" y1="7.75" x2="4.2" y2="11" width="0.127" layer="47"/>
+<wire x1="4.2" y1="11" x2="3.4" y2="11" width="0.127" layer="47"/>
+<wire x1="3.4" y1="11" x2="3.4" y2="7.75" width="0.127" layer="47"/>
+<wire x1="1.6" y1="7.75" x2="1.6" y2="11" width="0.127" layer="47"/>
+<wire x1="1.6" y1="11" x2="0.8" y2="11" width="0.127" layer="47"/>
+<wire x1="0.8" y1="11" x2="0.8" y2="7.75" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="7.75" x2="-0.9" y2="11" width="0.127" layer="47"/>
+<wire x1="-0.9" y1="11" x2="-1.7" y2="11" width="0.127" layer="47"/>
+<wire x1="-1.7" y1="11" x2="-1.7" y2="7.75" width="0.127" layer="47"/>
+<wire x1="-3.5" y1="7.75" x2="-3.5" y2="11" width="0.127" layer="47"/>
+<wire x1="-3.5" y1="11" x2="-4.25" y2="11" width="0.127" layer="47"/>
+<wire x1="-4.25" y1="11" x2="-4.25" y2="7.75" width="0.127" layer="47"/>
+<wire x1="-6" y1="7.75" x2="-6" y2="11" width="0.127" layer="47"/>
+<wire x1="-6" y1="11" x2="-6.8" y2="11" width="0.127" layer="47"/>
+<wire x1="-6.8" y1="11" x2="-6.8" y2="7.75" width="0.127" layer="47"/>
+<rectangle x1="-9" y1="-12.9" x2="9" y2="12.9" layer="41"/>
+<wire x1="-8.3" y1="-11.9" x2="-8.3" y2="7.75" width="0.127" layer="21"/>
+<wire x1="8.3" y1="7.75" x2="8.3" y2="-7.75" width="0.127" layer="21"/>
+<text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>
+<text x="0" y="0" size="1.5" layer="51" font="vector" ratio="10" align="center">&gt;NAME</text>
+<wire x1="-8.5" y1="12.5" x2="8.5" y2="12.5" width="0.127" layer="51"/>
+<wire x1="8.5" y1="12.5" x2="8.5" y2="-12.5" width="0.127" layer="51"/>
+</package>
 </packages>
 <symbols>
 <symbol name="2PRIMARY-1SECONDARY">
@@ -439,6 +534,53 @@
 <wire x1="2.54" y1="-20.32" x2="2.54" y2="-10.16" width="0.127" layer="94"/>
 <wire x1="2.54" y1="-10.16" x2="-2.54" y2="-10.16" width="0.127" layer="94"/>
 </symbol>
+<symbol name="2PRIMARY-3SECONDARY">
+<description>&lt;h3&gt;Transformer with primary and aux on primary side, 3 secondaries&lt;/h3&gt;
+&lt;p&gt;
+Transformer is designed with paralleling windings in mind. Some have multiple different output ratios for multivoltage systems (e.g. 12/5/3.3), others have several windings with same ratio for increased current capacity.
+&lt;/p&gt;</description>
+<wire x1="-10.16" y1="2.54" x2="-10.16" y2="0" width="0.254" layer="94" curve="-180"/>
+<wire x1="-10.16" y1="5.08" x2="-10.16" y2="2.54" width="0.254" layer="94" curve="-180"/>
+<wire x1="-10.16" y1="7.62" x2="-10.16" y2="5.08" width="0.254" layer="94" curve="-180"/>
+<circle x="-10.668" y="6.858" radius="0.254" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="-7.62" x2="-10.16" y2="-10.16" width="0.254" layer="94" curve="-180"/>
+<wire x1="-10.16" y1="-5.08" x2="-10.16" y2="-7.62" width="0.254" layer="94" curve="-180"/>
+<wire x1="-10.16" y1="-2.54" x2="-10.16" y2="-5.08" width="0.254" layer="94" curve="-180"/>
+<circle x="-10.668" y="-3.302" radius="0.254" width="0.254" layer="94"/>
+<wire x1="10.16" y1="0" x2="10.16" y2="2.54" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="-2.54" x2="10.16" y2="0" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="-5.08" x2="10.16" y2="-2.54" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="10.16" x2="10.16" y2="12.7" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="7.62" x2="10.16" y2="10.16" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="5.08" x2="10.16" y2="7.62" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="-10.16" x2="10.16" y2="-7.62" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="-12.7" x2="10.16" y2="-10.16" width="0.254" layer="94" curve="-180"/>
+<wire x1="10.16" y1="-15.24" x2="10.16" y2="-12.7" width="0.254" layer="94" curve="-180"/>
+<circle x="10.922" y="12.192" radius="0.254" width="0.254" layer="94"/>
+<circle x="10.922" y="2.032" radius="0.254" width="0.254" layer="94"/>
+<circle x="10.922" y="-8.128" radius="0.254" width="0.254" layer="94"/>
+<wire x1="-0.508" y1="-15.24" x2="-0.508" y2="13.208" width="0.254" layer="94"/>
+<wire x1="0.508" y1="13.208" x2="0.508" y2="-15.24" width="0.254" layer="94"/>
+<pin name="PRI+" x="-15.24" y="7.62" length="middle"/>
+<pin name="PRI-" x="-15.24" y="0" length="middle"/>
+<pin name="AUX+" x="-15.24" y="-2.54" length="middle"/>
+<pin name="AUX-" x="-15.24" y="-10.16" length="middle"/>
+<pin name="SEC1+" x="15.24" y="12.7" length="middle" rot="R180"/>
+<pin name="SEC1-" x="15.24" y="5.08" length="middle" rot="R180"/>
+<pin name="SEC2+" x="15.24" y="2.54" length="middle" rot="R180"/>
+<pin name="SEC2-" x="15.24" y="-5.08" length="middle" rot="R180"/>
+<pin name="SEC3+" x="15.24" y="-7.62" length="middle" rot="R180"/>
+<pin name="SEC3-" x="15.24" y="-15.24" length="middle" rot="R180"/>
+<wire x1="12.7" y1="-17.78" x2="-12.7" y2="-17.78" width="0.254" layer="94"/>
+<wire x1="-12.7" y1="-17.78" x2="-12.7" y2="15.24" width="0.254" layer="94"/>
+<wire x1="-12.7" y1="15.24" x2="12.7" y2="15.24" width="0.254" layer="94"/>
+<wire x1="12.7" y1="15.24" x2="12.7" y2="-17.78" width="0.254" layer="94"/>
+<text x="-16.764" y="3.302" size="1.27" layer="94">PRI</text>
+<text x="-17.018" y="-7.112" size="1.27" layer="94">AUX</text>
+<text x="13.97" y="8.382" size="1.27" layer="94">SEC</text>
+<text x="13.97" y="-2.032" size="1.27" layer="94">SEC</text>
+<text x="13.716" y="-12.192" size="1.27" layer="94">SEC</text>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="FLYBACK" prefix="T">
@@ -536,6 +678,31 @@
 <connect gate="G$1" pin="TX+" pad="16"/>
 <connect gate="G$1" pin="TX-" pad="14"/>
 <connect gate="G$1" pin="TXCT" pad="15"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="FLYBACK-3_OUTPUTS">
+<description>&lt;h3&gt;Flyback transformer with 3 output windings&lt;/h3&gt;</description>
+<gates>
+<gate name="G$1" symbol="2PRIMARY-3SECONDARY" x="-2.54" y="10.16"/>
+</gates>
+<devices>
+<device name="_749119350" package="WE_749119350">
+<connects>
+<connect gate="G$1" pin="AUX+" pad="P$5"/>
+<connect gate="G$1" pin="AUX-" pad="P$6"/>
+<connect gate="G$1" pin="PRI+" pad="P$1"/>
+<connect gate="G$1" pin="PRI-" pad="P$3"/>
+<connect gate="G$1" pin="SEC1+" pad="P$12"/>
+<connect gate="G$1" pin="SEC1-" pad="P$7"/>
+<connect gate="G$1" pin="SEC2+" pad="P$11"/>
+<connect gate="G$1" pin="SEC2-" pad="P$8"/>
+<connect gate="G$1" pin="SEC3+" pad="P$10"/>
+<connect gate="G$1" pin="SEC3-" pad="P$9"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/ELL-i-Transformers.lbr
+++ b/ELL-i-Transformers.lbr
@@ -369,7 +369,7 @@ Primary inductance is 120 uH, isolation voltage is 1,5 kV AC between primary and
 <wire x1="-6" y1="7.75" x2="-6" y2="11" width="0.127" layer="47"/>
 <wire x1="-6" y1="11" x2="-6.8" y2="11" width="0.127" layer="47"/>
 <wire x1="-6.8" y1="11" x2="-6.8" y2="7.75" width="0.127" layer="47"/>
-<rectangle x1="-9" y1="-12.9" x2="9" y2="12.9" layer="41"/>
+<rectangle x1="-9" y1="-12.9" x2="9" y2="12.9" layer="39"/>
 <wire x1="-8.3" y1="-11.9" x2="-8.3" y2="7.75" width="0.127" layer="21"/>
 <wire x1="8.3" y1="7.75" x2="8.3" y2="-7.75" width="0.127" layer="21"/>
 <text x="0" y="0" size="1.5" layer="25" font="vector" ratio="10" align="center">&gt;NAME</text>


### PR DESCRIPTION
Parts which PoElli-1.0 uses.

Ethernet connector 1888250-x should be discussed. Connector is done as manufacturer recommends, but it has too high insertion force in my subjective opinion. Signal lines could benefit from larger drill.

This pull request also includes plenty of earlier development, including fixing shield template drills etc.

Careful verification of parts is highly recommended before merging.
